### PR TITLE
ci: use make coverage

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -10,6 +10,8 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: 'stable'
+      - name: Get heighliner
+        run: make get-heighliner
       - name: Make local image
         run: make local-image
       - name: Run coverage

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -11,8 +11,10 @@ jobs:
         with:
           go-version: 'stable'
       - name: Run coverage
-        run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+        run: make coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4-beta
+        with:
+          file: coverage-filtered.out
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -11,7 +11,9 @@ jobs:
         with:
           go-version: 'stable'
       - name: Get heighliner
-        run: make get-heighliner
+        run: |
+          wget -c https://github.com/strangelove-ventures/heighliner/releases/download/v1.5.4/heighliner_1.5.4_linux_amd64.tar.gz -O - | tar -xz heighliner
+          mv heighliner /usr/local/bin
       - name: Make local image
         run: make local-image
       - name: Run coverage

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -10,6 +10,8 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: 'stable'
+      - name: Make local image
+        run: make local-image
       - name: Run coverage
         run: make coverage
       - name: Upload coverage to Codecov

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ test-integration:
 
 coverage: ## Run coverage report
 	@echo "--> Running coverage"
-	@go test -race -cpu=$$(nproc) -covermode=atomic -coverprofile=coverage.out $$(go list ./...) ./interchaintest/... -coverpkg=github.com/liftedinit/manifest-ledger/...
+	@go test -race -cpu=$$(nproc) -covermode=atomic -coverprofile=coverage.out $$(go list ./...) ./interchaintest/... -coverpkg=github.com/liftedinit/manifest-ledger/... > /dev/null 2>&1
 	@echo "--> Running coverage filter"
 	@./scripts/filter-coverage.sh
 	@echo "--> Running coverage report"

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ test-integration:
 
 coverage: ## Run coverage report
 	@echo "--> Running coverage"
-	@go test -race -cpu=$$(nproc) -covermode=atomic -coverprofile=coverage.out $$(go list ./...) ./interchaintest/... -coverpkg=github.com/liftedinit/manifest-ledger/... > /dev/null 2>&1
+	@go test -race -cpu=$$(nproc) -covermode=atomic -coverprofile=coverage.out $$(go list ./...) ./interchaintest/... -coverpkg=github.com/liftedinit/manifest-ledger/...
 	@echo "--> Running coverage filter"
 	@./scripts/filter-coverage.sh
 	@echo "--> Running coverage report"


### PR DESCRIPTION
Use `make coverage` and upload filtered results to codecov.

Image caching and optimization can be part of future work.