### PR TITLE
chore: remove panic usage in keeper methods

### DIFF
--- a/x/manifest/abci.go
+++ b/x/manifest/abci.go
@@ -33,7 +33,10 @@ func BeginBlocker(ctx context.Context, k keeper.Keeper, mk mintkeeper.Keeper) er
 	}
 
 	// Calculate the per block inflation rewards to pay out in coins
-	mintedCoin := k.BlockRewardsProvision(ctx, params.Inflation.MintDenom)
+	mintedCoin, err := k.BlockRewardsProvision(ctx, params.Inflation.MintDenom)
+	if err != nil {
+		return err
+	}
 	mintedCoins := sdk.NewCoins(mintedCoin)
 
 	// If no inflation payout this block, skip

--- a/x/manifest/keeper/msg_server_test.go
+++ b/x/manifest/keeper/msg_server_test.go
@@ -225,7 +225,8 @@ func TestCalculatePayoutLogic(t *testing.T) {
 	require.NoError(t, err)
 
 	// validate the full payout of 100 tokens got split up between all fractional shares as expected
-	res := k.CalculateShareHolderTokenPayout(f.Ctx, sdk.NewCoin("stake", sdkmath.NewInt(100_000_000)))
+	res, err := k.CalculateShareHolderTokenPayout(f.Ctx, sdk.NewCoin("stake", sdkmath.NewInt(100_000_000)))
+	require.NoError(t, err)
 	for _, s := range sh {
 		for w, shp := range res {
 			if s.Address == shp.Address {


### PR DESCRIPTION
This PR removes the panic usage in keeper methods. This should fix the remaining CodeQL warnings.

Code hygiene following https://github.com/cosmos/cosmos-sdk/pull/18636, https://github.com/cosmos/cosmos-sdk/pull/16212 and https://github.com/cosmos/cosmos-sdk/issues/12985