### PR TITLE
fix: initialize tokenfactory before bank module

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -784,6 +784,7 @@ func NewApp(
 	genesisModuleOrder := []string{
 		capabilitytypes.ModuleName,
 		// simd modules
+		tokenfactorytypes.ModuleName, // before bank
 		authtypes.ModuleName, banktypes.ModuleName,
 		distrtypes.ModuleName, stakingtypes.ModuleName, slashingtypes.ModuleName, govtypes.ModuleName,
 		minttypes.ModuleName, crisistypes.ModuleName, genutiltypes.ModuleName, evidencetypes.ModuleName, authz.ModuleName,
@@ -794,7 +795,6 @@ func NewApp(
 		ibcexported.ModuleName,
 		icatypes.ModuleName,
 		ibcfeetypes.ModuleName,
-		tokenfactorytypes.ModuleName,
 		poa.ModuleName,
 		manifesttypes.ModuleName,
 	}


### PR DESCRIPTION
The `TokenFactory` module should be initialized *before* the bank module otherwise it will overwrite the denom metadata.

See https://github.com/strangelove-ventures/tokenfactory/blob/9f137b7ba03210d74d685a965da2613316bc3e93/x/tokenfactory/keeper/createdenom.go#L28-L39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved initialization sequence for the token factory module, enhancing its integration with other functionalities.
	- Updated block processing lifecycle to include the token factory module.

- **Bug Fixes**
	- Ensured proper order of module initialization and exportation, potentially resolving issues related to module interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->