### PR TITLE
feat: umfx denom metadata migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DOCKER := $(shell which docker)
 LEDGER_ENABLED ?= true
 BINDIR ?= $(GOPATH)/bin
 BUILD_DIR = ./build
-VERSION = v0.0.1-alpha.17
+VERSION = v0.0.1-alpha.18
 
 export GO111MODULE = on
 

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -19,7 +19,7 @@ func (app *ManifestApp) RegisterUpgradeHandlers() {
 		Upgrades = append(Upgrades, noop.NewUpgrade(app.Version()))
 	}
 
-	keepers := upgrades.AppKeepers{AccountKeeper: app.AccountKeeper}
+	keepers := upgrades.AppKeepers{AccountKeeper: app.AccountKeeper, BankKeeper: app.BankKeeper}
 	// register all upgrade handlers
 	for _, upgrade := range Upgrades {
 		app.UpgradeKeeper.SetUpgradeHandler(

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 
 	upgradetypes "cosmossdk.io/x/upgrade/types"
+	"github.com/liftedinit/manifest-ledger/app/upgrades/next"
 
 	"github.com/liftedinit/manifest-ledger/app/upgrades"
 	"github.com/liftedinit/manifest-ledger/app/upgrades/noop"
 )
 
 // Upgrades list of chain upgrades
-var Upgrades []upgrades.Upgrade
+var Upgrades = []upgrades.Upgrade{next.NewUpgrade()}
 
 // RegisterUpgradeHandlers registers the chain upgrade handlers
 func (app *ManifestApp) RegisterUpgradeHandlers() {

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 
 	upgradetypes "cosmossdk.io/x/upgrade/types"
-	"github.com/liftedinit/manifest-ledger/app/upgrades/next"
 
 	"github.com/liftedinit/manifest-ledger/app/upgrades"
+	"github.com/liftedinit/manifest-ledger/app/upgrades/next"
 	"github.com/liftedinit/manifest-ledger/app/upgrades/noop"
 )
 

--- a/app/upgrades/next/upgrades.go
+++ b/app/upgrades/next/upgrades.go
@@ -7,13 +7,8 @@ import (
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	"github.com/liftedinit/manifest-ledger/app"
 	"github.com/liftedinit/manifest-ledger/app/upgrades"
 )
-
-func init() {
-	app.Upgrades = append(app.Upgrades, NewUpgrade())
-}
 
 func NewUpgrade() upgrades.Upgrade {
 	return upgrades.Upgrade{

--- a/app/upgrades/next/upgrades.go
+++ b/app/upgrades/next/upgrades.go
@@ -1,0 +1,59 @@
+package next
+
+import (
+	"context"
+
+	storetypes "cosmossdk.io/store/types"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/liftedinit/manifest-ledger/app"
+	"github.com/liftedinit/manifest-ledger/app/upgrades"
+)
+
+func init() {
+	app.Upgrades = append(app.Upgrades, NewUpgrade())
+}
+
+func NewUpgrade() upgrades.Upgrade {
+	return upgrades.Upgrade{
+		UpgradeName:          "umfx-denom-metadata",
+		CreateUpgradeHandler: CreateUpgradeHandler,
+		StoreUpgrades: storetypes.StoreUpgrades{
+			Added:   []string{},
+			Deleted: []string{},
+		},
+	}
+}
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	keepers *upgrades.AppKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(ctx context.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		metadata := banktypes.Metadata{
+			Description: "The Manifest Network token",
+			DenomUnits: []*banktypes.DenomUnit{
+				{
+					Denom:    "umfx",
+					Exponent: 0,
+					Aliases:  []string{},
+				},
+				{
+					Denom:    "MFX",
+					Exponent: 6,
+					Aliases:  []string{},
+				},
+			},
+			Base:    "umfx",
+			Display: "MFX",
+			Symbol:  "MFX",
+		}
+
+		// Set the new metadata in the bank keeper
+		keepers.BankKeeper.SetDenomMetaData(ctx, metadata)
+
+		return mm.RunMigrations(ctx, configurator, fromVM)
+	}
+}

--- a/app/upgrades/next/upgrades.go
+++ b/app/upgrades/next/upgrades.go
@@ -5,8 +5,10 @@ import (
 
 	storetypes "cosmossdk.io/store/types"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
+
 	"github.com/cosmos/cosmos-sdk/types/module"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+
 	"github.com/liftedinit/manifest-ledger/app/upgrades"
 )
 
@@ -42,9 +44,9 @@ func CreateUpgradeHandler(
 				},
 			},
 			Base:    "umfx",
-			Display: "mfx",
+			Display: "MFX",
 			Symbol:  "MFX",
-			Name:    "Manifest Token",
+			Name:    "Manifest Network Token",
 		}
 
 		// Set the new metadata in the bank keeper

--- a/app/upgrades/next/upgrades.go
+++ b/app/upgrades/next/upgrades.go
@@ -36,13 +36,13 @@ func CreateUpgradeHandler(
 					Aliases:  []string{},
 				},
 				{
-					Denom:    "MFX",
+					Denom:    "mfx",
 					Exponent: 6,
 					Aliases:  []string{},
 				},
 			},
 			Base:    "umfx",
-			Display: "MFX",
+			Display: "mfx",
 			Symbol:  "MFX",
 			Name:    "Manifest Token",
 		}

--- a/app/upgrades/next/upgrades.go
+++ b/app/upgrades/next/upgrades.go
@@ -44,6 +44,7 @@ func CreateUpgradeHandler(
 			Base:    "umfx",
 			Display: "MFX",
 			Symbol:  "MFX",
+			Name:    "Manifest Token",
 		}
 
 		// Set the new metadata in the bank keeper

--- a/app/upgrades/types.go
+++ b/app/upgrades/types.go
@@ -3,13 +3,15 @@ package upgrades
 import (
 	storetypes "cosmossdk.io/store/types"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 
 	"github.com/cosmos/cosmos-sdk/types/module"
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 )
 
 type AppKeepers struct {
-	authkeeper.AccountKeeper
+	AccountKeeper authkeeper.AccountKeeper
+	BankKeeper    bankkeeper.BaseKeeper
 }
 
 // Upgrade defines a struct containing necessary fields that a SoftwareUpgradeProposal

--- a/app/upgrades/types.go
+++ b/app/upgrades/types.go
@@ -3,10 +3,10 @@ package upgrades
 import (
 	storetypes "cosmossdk.io/store/types"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
-	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 
 	"github.com/cosmos/cosmos-sdk/types/module"
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 )
 
 type AppKeepers struct {


### PR DESCRIPTION
This PR adds the `umfx-denom-metadata` migration that adds the following bank denom metadata for the `umfx` token

```go
metadata := banktypes.Metadata{
	Description: "The Manifest Network token",
	DenomUnits: []*banktypes.DenomUnit{
		{
			Denom:    "umfx",
			Exponent: 0,
			Aliases:  []string{},
		},
		{
			Denom:    "mfx",
			Exponent: 6,
			Aliases:  []string{},
		},
	},
	Base:    "umfx",
	Display: "MFX",
	Symbol:  "MFX",
	Name:    "Manifest Network Token",
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new upgrade mechanism, ensuring at least one upgrade is registered.
	- Added a new upgrade "umfx-denom-metadata" with metadata for the Manifest Network token.

- **Improvements**
	- Enhanced upgrade handling logic by including banking functionalities.

- **Bug Fixes**
	- Updated versioning to reflect the latest changes (v0.0.1-alpha.18).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->