### PR TITLE
chore: prepare v1.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DOCKER := $(shell which docker)
 LEDGER_ENABLED ?= true
 BINDIR ?= $(GOPATH)/bin
 BUILD_DIR = ./build
-VERSION = v0.0.1-rc.6
+VERSION = v1.0.0
 
 export GO111MODULE = on
 

--- a/app/upgrades/next/upgrades.go
+++ b/app/upgrades/next/upgrades.go
@@ -3,15 +3,11 @@ package next
 import (
 	"context"
 
-	errorsmod "cosmossdk.io/errors"
 	storetypes "cosmossdk.io/store/types"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 
 	"github.com/cosmos/cosmos-sdk/types/module"
 
-	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
-
-	"github.com/liftedinit/manifest-ledger/app/helpers"
 	"github.com/liftedinit/manifest-ledger/app/upgrades"
 )
 
@@ -20,9 +16,7 @@ func NewUpgrade(name string) upgrades.Upgrade {
 		UpgradeName:          name,
 		CreateUpgradeHandler: CreateUpgradeHandler,
 		StoreUpgrades: storetypes.StoreUpgrades{
-			Added: []string{
-				wasmtypes.ModuleName,
-			},
+			Added:   []string{},
 			Deleted: []string{},
 		},
 	}
@@ -31,26 +25,9 @@ func NewUpgrade(name string) upgrades.Upgrade {
 func CreateUpgradeHandler(
 	mm *module.Manager,
 	configurator module.Configurator,
-	keepers *upgrades.AppKeepers,
+	_ *upgrades.AppKeepers,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx context.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		fromVM, err := mm.RunMigrations(ctx, configurator, fromVM)
-		if err != nil {
-			return fromVM, err
-		}
-
-		// Set CosmWasm params
-		wasmParams := wasmtypes.DefaultParams()
-		wasmParams.CodeUploadAccess = wasmtypes.AccessConfig{
-			Permission: wasmtypes.AccessTypeAnyOfAddresses,
-			Addresses:  []string{helpers.GetPoAAdmin()},
-		}
-		wasmParams.InstantiateDefaultPermission = wasmtypes.AccessTypeAnyOfAddresses
-
-		if err := keepers.WasmKeeper.SetParams(ctx, wasmParams); err != nil {
-			return fromVM, errorsmod.Wrapf(err, "unable to set CosmWasm params")
-		}
-
-		return fromVM, nil
+		return mm.RunMigrations(ctx, configurator, fromVM)
 	}
 }

--- a/interchaintest/chain_upgrade_test.go
+++ b/interchaintest/chain_upgrade_test.go
@@ -59,6 +59,8 @@ var (
 )
 
 func TestBasicManifestUpgrade(t *testing.T) {
+	t.Skip("Skipping test, we know the migration to rc.6 works")
+
 	if testing.Short() {
 		t.Skip("skipping in short mode")
 	}


### PR DESCRIPTION
This PR
- bumps the version number to v1.0.0
- set the chain upgrade to a noop
- disable the chain upgrade test used for the rc.6 wasm upgrade


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded the application version to v1.0.0, marking the transition from a pre-release candidate to a stable release.
  
- **Refactor**
  - Streamlined the upgrade process by removing outdated upgrade handling methods.
  
- **Tests**
  - Modified migration tests to skip redundant validations, ensuring an efficient testing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->