### PR TITLE
fix: reduce group metadata limit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,9 @@ ictest-cosmwasm:
 ictest-chain-upgrade:
 	cd interchaintest && go test -race -v -run TestBasicManifestUpgrade . -count=1
 
+ictest-group:
+	cd interchaintest && go test -race -v -run TestGroupMetadataLimits . -count=1
+
 .PHONY: ictest-ibc ictest-tokenfactory
 
 ###############################################################################

--- a/app/app.go
+++ b/app/app.go
@@ -489,7 +489,7 @@ func NewApp(
 	)
 
 	groupConfig := group.DefaultConfig()
-	groupConfig.MaxMetadataLen = 100_000
+	groupConfig.MaxMetadataLen = 2048 // 2KB
 	app.GroupKeeper = groupkeeper.NewKeeper(
 		keys[group.StoreKey],
 		// runtime.NewKVStoreService(keys[group.StoreKey]),

--- a/interchaintest/group_test.go
+++ b/interchaintest/group_test.go
@@ -1,0 +1,76 @@
+package interchaintest
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/liftedinit/manifest-ledger/interchaintest/helpers"
+	"github.com/strangelove-ventures/interchaintest/v8"
+	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
+	"github.com/strangelove-ventures/interchaintest/v8/testreporter"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
+)
+
+const GroupMetadataLimit = 2048
+
+func TestGroupMetadataLimits(t *testing.T) {
+	ctx := context.Background()
+
+	cfgA := LocalChainConfig
+	cfgA.Name = "manifest-2"
+	cfgA.WithCodeCoverage()
+
+	cf := interchaintest.NewBuiltinChainFactory(zaptest.NewLogger(t, zaptest.Level(zapcore.DebugLevel)), []*interchaintest.ChainSpec{
+		{
+			Name:          "manifest",
+			Version:       "local",
+			ChainName:     cfgA.ChainID,
+			NumValidators: &vals,
+			NumFullNodes:  &fullNodes,
+			ChainConfig:   cfgA,
+		},
+	})
+	chains, err := cf.Chains(t.Name())
+	require.NoError(t, err)
+
+	appChain := chains[0].(*cosmos.CosmosChain)
+
+	client, network := interchaintest.DockerSetup(t)
+
+	ic := interchaintest.NewInterchain().
+		AddChain(appChain)
+
+	rep := testreporter.NewNopReporter()
+	eRep := rep.RelayerExecReporter(t)
+
+	require.NoError(t, ic.Build(ctx, eRep, interchaintest.InterchainBuildOptions{
+		TestName:         t.Name(),
+		Client:           client,
+		NetworkID:        network,
+		SkipPathCreation: false,
+	}))
+
+	users := interchaintest.GetAndFundTestUsers(t, ctx, "default", DefaultGenesisAmt, appChain)
+	admin := users[0]
+	adminAddr := admin.FormattedAddress()
+
+	t.Run("success: create group with exact metadata limit", func(t *testing.T) {
+		groupMetadata := strings.Repeat("A", GroupMetadataLimit)
+		_, err := helpers.CreateGroupWithMetadata(ctx, t, appChain, adminAddr, groupMetadata)
+		require.NoError(t, err)
+	})
+
+	t.Run("fail: create group with over metadata limit", func(t *testing.T) {
+		groupMetadata := strings.Repeat("A", GroupMetadataLimit+1)
+		_, err := helpers.CreateGroupWithMetadata(ctx, t, appChain, adminAddr, groupMetadata)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "group metadata: limit exceeded")
+	})
+
+	t.Cleanup(func() {
+		_ = ic.Close()
+	})
+}


### PR DESCRIPTION
This PR lowers the group metadata limit from 100_000 to 2048.

The 100_000 limit could be used as an attack vector to fill the chain with garbage data for cheap.

2KB of metadata should be enough for everyone.

This PR also adds an e2e test covering the group metadata limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enforced a stricter group metadata limit of 2KB for more consistent data handling.
- **Tests**
	- Expanded test coverage to ensure proper validation and error handling when group metadata exceeds the allowed limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->