### PR TITLE
feat!: disable ibc transfer, for now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DOCKER := $(shell which docker)
 LEDGER_ENABLED ?= true
 BINDIR ?= $(GOPATH)/bin
 BUILD_DIR = ./build
-VERSION = v1.0.3
+VERSION = v1.0.4-rc.1
 
 export GO111MODULE = on
 

--- a/app/ante.go
+++ b/app/ante.go
@@ -3,6 +3,7 @@ package app
 import (
 	"errors"
 
+	"github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
 	ibcante "github.com/cosmos/ibc-go/v8/modules/core/ante"
 	"github.com/cosmos/ibc-go/v8/modules/core/keeper"
 
@@ -18,6 +19,8 @@ import (
 
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+
+	"github.com/liftedinit/manifest-ledger/app/decorators"
 )
 
 type RateMinMax struct {
@@ -88,6 +91,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		poaante.NewPOADisableWithdrawDelegatorRewards(),
 		poaante.NewCommissionLimitDecorator(doGenTxRateValidation, options.RateMinMax.Floor, options.RateMinMax.Ceil),
 		ibcante.NewRedundantRelayDecorator(options.IBCKeeper),
+		decorators.FilterDecorator(&types.MsgTransfer{}), // TODO: Remove this when we allow IBC transfers
 	}
 
 	return sdk.ChainAnteDecorators(anteDecorators...), nil

--- a/app/decorators/msg_filter.go
+++ b/app/decorators/msg_filter.go
@@ -1,0 +1,62 @@
+package decorators
+
+// Taken from https://github.com/rollchains/spawn/blob/release/v0.50/simapp/app/decorators/msg_filter_template.go @ e332ed
+
+import (
+	"fmt"
+
+	"github.com/cosmos/gogoproto/proto"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+)
+
+// MsgFilterDecorator is an ante.go decorator template for filtering messages.
+type MsgFilterDecorator struct {
+	blockedTypes []sdk.Msg
+}
+
+// FilterDecorator returns a new MsgFilterDecorator. This errors if the transaction
+// contains any of the blocked message types.
+//
+// Example:
+// - decorators.FilterDecorator(&banktypes.MsgSend{})
+// This would block any MsgSend messages from being included in a transaction if set in ante.go
+func FilterDecorator(blockedMsgTypes ...sdk.Msg) MsgFilterDecorator {
+	return MsgFilterDecorator{
+		blockedTypes: blockedMsgTypes,
+	}
+}
+
+func (mfd MsgFilterDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	if mfd.HasDisallowedMessage(ctx, tx.GetMsgs()) {
+		currHeight := ctx.BlockHeight()
+		return ctx, fmt.Errorf("tx contains unsupported message types at height %d", currHeight)
+	}
+
+	return next(ctx, tx, simulate)
+}
+
+func (mfd MsgFilterDecorator) HasDisallowedMessage(ctx sdk.Context, msgs []sdk.Msg) bool {
+	for _, msg := range msgs {
+		// check nested messages in a recursive manner
+		if execMsg, ok := msg.(*authz.MsgExec); ok {
+			msgs, err := execMsg.GetMessages()
+			if err != nil {
+				return true
+			}
+
+			if mfd.HasDisallowedMessage(ctx, msgs) {
+				return true
+			}
+		}
+
+		for _, blockedType := range mfd.blockedTypes {
+			if proto.MessageName(msg) == proto.MessageName(blockedType) {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/app/decorators/msg_filter_test.go
+++ b/app/decorators/msg_filter_test.go
@@ -1,0 +1,62 @@
+package decorators_test
+
+// Adapted from https://github.com/rollchains/spawn/blob/release/v0.50/simapp/app/decorators/msg_filter_test.go @ e332edf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/cometbft/cometbft/crypto/secp256k1"
+
+	"github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
+	ibctypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
+
+	sdkmath "cosmossdk.io/math"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+
+	"github.com/liftedinit/manifest-ledger/app/decorators"
+)
+
+type AnteTestSuite struct {
+	suite.Suite
+
+	ctx sdk.Context
+}
+
+func TestAnteTestSuite(t *testing.T) {
+	suite.Run(t, new(AnteTestSuite))
+}
+
+func (s *AnteTestSuite) TestAnteMsgFilterLogic() {
+	acc := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
+
+	// test blocking any MsgTransfer Messages
+	ante := decorators.FilterDecorator(&types.MsgTransfer{})
+	msg := types.NewMsgTransfer(
+		"transfer/channel-0",
+		"transfer/channel-0",
+		sdk.NewCoin("umfl", sdkmath.NewInt(1)),
+		acc.String(),
+		acc.String(),
+		ibctypes.Height{
+			RevisionNumber: 0,
+			RevisionHeight: 0,
+		},
+		0,
+		"memo",
+	)
+	_, err := ante.AnteHandle(s.ctx, decorators.NewMockTx(msg), false, decorators.EmptyAnte)
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "tx contains unsupported message types")
+
+	// validate other messages go through still
+	msgMultiSend := banktypes.NewMsgMultiSend(
+		banktypes.NewInput(acc, sdk.NewCoins(sdk.NewCoin("umfx", sdkmath.NewInt(1)))),
+		[]banktypes.Output{banktypes.NewOutput(acc, sdk.NewCoins(sdk.NewCoin("umfx", sdkmath.NewInt(1))))},
+	)
+	_, err = ante.AnteHandle(s.ctx, decorators.NewMockTx(msgMultiSend), false, decorators.EmptyAnte)
+	s.Require().NoError(err)
+}

--- a/app/decorators/setup.go
+++ b/app/decorators/setup.go
@@ -1,0 +1,35 @@
+package decorators
+
+// Taken from https://github.com/rollchains/spawn/blob/release/v0.50/simapp/app/decorators/setup.go @ e332edf
+
+import (
+	protov2 "google.golang.org/protobuf/proto"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+var EmptyAnte = func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+	return ctx, nil
+}
+
+type MockTx struct {
+	msgs []sdk.Msg
+}
+
+func NewMockTx(msgs ...sdk.Msg) MockTx {
+	return MockTx{
+		msgs: msgs,
+	}
+}
+
+func (tx MockTx) GetMsgs() []sdk.Msg {
+	return tx.msgs
+}
+
+func (tx MockTx) GetMsgsV2() ([]protov2.Message, error) {
+	return nil, nil
+}
+
+func (tx MockTx) ValidateBasic() error {
+	return nil
+}

--- a/interchaintest/group_test.go
+++ b/interchaintest/group_test.go
@@ -5,13 +5,14 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/liftedinit/manifest-ledger/interchaintest/helpers"
 	"github.com/strangelove-ventures/interchaintest/v8"
 	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
 	"github.com/strangelove-ventures/interchaintest/v8/testreporter"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
+
+	"github.com/liftedinit/manifest-ledger/interchaintest/helpers"
 )
 
 const GroupMetadataLimit = 2048

--- a/interchaintest/ibc_test.go
+++ b/interchaintest/ibc_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"cosmossdk.io/math"
-	transfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
 	"github.com/strangelove-ventures/interchaintest/v8"
 	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
 	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
@@ -102,9 +101,9 @@ func TestIBC(t *testing.T) {
 	require.NoError(t, err)
 	manifestAChannelID := manifestAChannelInfo[0].ChannelID
 
-	osmoChannelInfo, err := r.GetChannels(ctx, eRep, manifestB.Config().ChainID)
-	require.NoError(t, err)
-	osmoChannelID := osmoChannelInfo[0].ChannelID
+	//osmoChannelInfo, err := r.GetChannels(ctx, eRep, manifestB.Config().ChainID)
+	//require.NoError(t, err)
+	//osmoChannelID := osmoChannelInfo[0].ChannelID
 
 	// Send Transaction
 	amountToSend := math.NewInt(1_000_000)
@@ -115,26 +114,29 @@ func TestIBC(t *testing.T) {
 		Amount:  amountToSend,
 	}
 
+	// TODO: Re-enable once IBC Transfer are allowed again
 	_, err = manifestA.SendIBCTransfer(ctx, manifestAChannelID, manifestAUser.KeyName(), transfer, ibc.TransferOptions{})
-	require.NoError(t, err)
-
-	// relay MsgRecvPacket to manifestB, then MsgAcknowledgement back to manifestA
-	require.NoError(t, r.Flush(ctx, eRep, ibcPath, manifestAChannelID))
-
-	// test source wallet has decreased funds
-	expectedBal := manifestAUserBalInitial.Sub(amountToSend)
-	manifestAUserBalNew, err := manifestA.GetBalance(ctx, manifestAUser.FormattedAddress(), manifestA.Config().Denom)
-	require.NoError(t, err)
-	require.True(t, manifestAUserBalNew.Equal(expectedBal))
-
-	// Trace IBC Denom
-	srcDenomTrace := transfertypes.ParseDenomTrace(transfertypes.GetPrefixedDenom("transfer", osmoChannelID, manifestA.Config().Denom))
-	dstIbcDenom := srcDenomTrace.IBCDenom()
-
-	// Test destination wallet has increased funds
-	osmosUserBalNew, err := manifestB.GetBalance(ctx, manifestBUser.FormattedAddress(), dstIbcDenom)
-	require.NoError(t, err)
-	require.True(t, osmosUserBalNew.Equal(amountToSend))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "tx contains unsupported message types")
+	//require.NoError(t, err)
+	//
+	//// relay MsgRecvPacket to manifestB, then MsgAcknowledgement back to manifestA
+	//require.NoError(t, r.Flush(ctx, eRep, ibcPath, manifestAChannelID))
+	//
+	//// test source wallet has decreased funds
+	//expectedBal := manifestAUserBalInitial.Sub(amountToSend)
+	//manifestAUserBalNew, err := manifestA.GetBalance(ctx, manifestAUser.FormattedAddress(), manifestA.Config().Denom)
+	//require.NoError(t, err)
+	//require.True(t, manifestAUserBalNew.Equal(expectedBal))
+	//
+	//// Trace IBC Denom
+	//srcDenomTrace := transfertypes.ParseDenomTrace(transfertypes.GetPrefixedDenom("transfer", osmoChannelID, manifestA.Config().Denom))
+	//dstIbcDenom := srcDenomTrace.IBCDenom()
+	//
+	//// Test destination wallet has increased funds
+	//osmosUserBalNew, err := manifestB.GetBalance(ctx, manifestBUser.FormattedAddress(), dstIbcDenom)
+	//require.NoError(t, err)
+	//require.True(t, osmosUserBalNew.Equal(amountToSend))
 
 	t.Cleanup(func() {
 		dockerutil.CopyCoverageFromContainer(ctx, t, client, manifestA.GetNode().ContainerID(), manifestA.HomeDir(), ExternalGoCoverDir)

--- a/scripts/test_node.sh
+++ b/scripts/test_node.sh
@@ -74,7 +74,7 @@ from_scratch () {
 
   # group
   update_test_genesis '.app_state["group"]["group_seq"]="1"'
-  update_test_genesis '.app_state["group"]["groups"]=[{"id": "1", "admin": "manifest1afk9zr2hn2jsac63h4hm60vl9z3e5u69gndzf7c99cqge3vzwjzsfmy9qj", "metadata": "AQ==", "version": "2", "total_weight": "2", "created_at": "2024-05-16T15:10:54.372190727Z"}]'
+  update_test_genesis '.app_state["group"]["groups"]=[{"id": "1", "admin": "manifest1afk9zr2hn2jsac63h4hm60vl9z3e5u69gndzf7c99cqge3vzwjzsfmy9qj", "metadata": "'\{\\\"title\\\":\\\"POA\ Admin\\\",\\\"authors\\\":\[\\\"manifest1afk9zr2hn2jsac63h4hm60vl9z3e5u69gndzf7c99cqge3vzwjzsfmy9qj\\\"\],\\\"details\\\":\\\"The\ Manifest\ network\ governance\ body\\\"\}'", "version": "2", "total_weight": "2", "created_at": "2024-05-16T15:10:54.372190727Z"}]'
   update_test_genesis '.app_state["group"]["group_members"]=[{"group_id": "1", "member": {"address": "manifest1hj5fveer5cjtn4wd6wstzugjfdxzl0xp8ws9ct", "weight": "1", "metadata": "user1", "added_at": "2024-05-16T15:10:54.372190727Z"}}, {"group_id": "1", "member": {"address": "manifest1efd63aw40lxf3n4mhf7dzhjkr453axurm6rp3z", "weight": "1", "metadata": "user2", "added_at": "2024-05-16T15:10:54.372190727Z"}}]'
   update_test_genesis '.app_state["group"]["group_policy_seq"]="1"'
   update_test_genesis '.app_state["group"]["group_policies"]=[{"address": "manifest1afk9zr2hn2jsac63h4hm60vl9z3e5u69gndzf7c99cqge3vzwjzsfmy9qj", "group_id": "1", "admin": "manifest1afk9zr2hn2jsac63h4hm60vl9z3e5u69gndzf7c99cqge3vzwjzsfmy9qj", "metadata": "AQ==", "version": "2", "decision_policy": { "@type": "/cosmos.group.v1.ThresholdDecisionPolicy", "threshold": "1", "windows": {"voting_period": "30s", "min_execution_period": "0s"}}, "created_at": "2024-05-16T15:10:54.372190727Z"}]'


### PR DESCRIPTION
This PR disables `MsgTransfer` message type. We will remove this filter when we're ready for public listing.

This PR also correctly sets the POA group metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a transaction filtering system that automatically blocks unsupported message types, enhancing transaction security.
  - Upgraded group metadata details by replacing generic placeholders with descriptive JSON data for clearer governance information.

- **Tests**
  - Added comprehensive tests to verify the correct operation of the transaction filter and validate overall processing behavior.

- **Chores**
  - Updated version to `v1.0.4-rc.1`, indicating a transition to a release candidate state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->