### PR TITLE
docs: update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,11 +13,11 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 
 > If you want to ask a question, we assume that you have read the available [Documentation](./README.md).
 
-Before you ask a question, it is best to search for existing [Issues](/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
+Before you ask a question, it is best to search for existing [Issues](https://github.com/manifest-network/manifest-ledger/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
 
 If you then still feel the need to ask a question and need clarification, we recommend the following:
 
-- Open an [Issue](/issues/new).
+- Open an [Issue](https://github.com/manifest-network/manifest-ledger/issues/new).
 - Select a template and stick to its guidelines.
 - Provide as much context as you can about what you're running into.
 - Provide project and platform versions (os, arch, go, etc.), depending on what seems relevant.
@@ -49,15 +49,15 @@ Please complete the following steps in advance to help us fix any potential bug 
 
 We use GitHub issues to track bugs and errors. If you run into an issue with the project:
 
-- Open an [Issue](/issues/new).
+- Open an [Issue](https://github.com/manifest-network/manifest-ledger/issues/new).
 - Explain the behavior you would expect and the actual behavior.
 - Please provide as much context as possible and describe the _reproduction steps_ that someone else can follow to recreate the issue on their own. This usually includes your code. For good bug reports you should isolate the problem and create a reduced test case.
 - Provide the information you collected in the previous section.
 
 ## I Want To Open A Pull Request
 
-Before opening a pull request, please make sure to read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
+We use the [GitHub Flow](https://guides.github.com/introduction/flow/index.html) for our development process: fork the repository, create a branch for your changes, and open a pull request against `main` when you're ready.
 
-We are using the [GitHub Flow](https://guides.github.com/introduction/flow/index.html) for our development process. This means that you should fork this repository and create a branch for your changes. After you are done with your changes, open a pull request to the `main` branch of this repository.
+PRs created without filling in the PR template will be ignored and closed. Please follow the template as best as you can, removing any irrelevant sections and filling in the rest to the best of your ability.
 
-Any PR's created without the PR template will be ignored and closed. Please follow the template as best as you can, removing any irrelevant sections and filling in the rest to the best of your ability.
+Make sure your changes follow the project conventions captured in [`CLAUDE.md`](./CLAUDE.md) (build commands, linting, import order, Cosmos SDK patterns) — CI runs `make lint`, `make vet`, `make govulncheck`, and the unit/integration test suites, so verifying locally first will save a round-trip.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,4 +60,4 @@ We use the [GitHub Flow](https://guides.github.com/introduction/flow/index.html)
 
 PRs created without filling in the PR template will be ignored and closed. Please follow the template as best as you can, removing any irrelevant sections and filling in the rest to the best of your ability.
 
-Make sure your changes follow the project conventions captured in [`CLAUDE.md`](./CLAUDE.md) (build commands, linting, import order, Cosmos SDK patterns) — CI runs `make lint`, `make vet`, `make govulncheck`, and the unit/integration test suites, so verifying locally first will save a round-trip.
+Make sure your changes follow the project conventions captured in [`CLAUDE.md`](./CLAUDE.md) (build commands, linting, import order, Cosmos SDK patterns) — CI runs `make lint`, `make build`, the unit-test suite (`make test`), the e2e integration matrix (`make ictest-*`), and the simulation suite (`make sim-*`) — see [`.github/workflows/`](./.github/workflows/) for the canonical list. Verifying locally first will save a round-trip.

--- a/MODULE.md
+++ b/MODULE.md
@@ -53,7 +53,7 @@
       - [Close Lease (close-lease)](#close-lease-close-lease)
       - [Withdraw (withdraw)](#withdraw-withdraw)
       - [Set Item Custom Domain (set-item-custom-domain)](#set-item-custom-domain-set-item-custom-domain)
-      - [Update Params (update-params)](#update-params-update-params-2)
+      - [Update Params (update-params)](#update-params-update-params-1)
 
 <!-- TOC -->
 

--- a/MODULE.md
+++ b/MODULE.md
@@ -44,6 +44,16 @@
 - [Billing Module](#billing-module)
   - [Module Functionality](#module-functionality-5)
     - [Commands](#commands-5)
+      - [Fund Credit (fund-credit)](#fund-credit-fund-credit)
+      - [Create Lease (create-lease)](#create-lease-create-lease)
+      - [Create Lease For Tenant (create-lease-for-tenant)](#create-lease-for-tenant-create-lease-for-tenant)
+      - [Acknowledge Lease (acknowledge-lease)](#acknowledge-lease-acknowledge-lease)
+      - [Reject Lease (reject-lease)](#reject-lease-reject-lease)
+      - [Cancel Lease (cancel-lease)](#cancel-lease-cancel-lease)
+      - [Close Lease (close-lease)](#close-lease-close-lease)
+      - [Withdraw (withdraw)](#withdraw-withdraw)
+      - [Set Item Custom Domain (set-item-custom-domain)](#set-item-custom-domain-set-item-custom-domain)
+      - [Update Params (update-params)](#update-params-update-params-2)
 
 <!-- TOC -->
 
@@ -526,6 +536,25 @@ The Billing module implements a credit-based leasing system for AI infrastructur
 
   **Example:** `manifestd tx billing withdraw 01912345-6789-7abc-8def-0123456789ab --from provider`
 
+##### Set Item Custom Domain (set-item-custom-domain):
+
+Set or clear the custom domain on a specific lease item. Authorised senders are
+the lease tenant, the module authority, or any address in `params.allowed_list`.
+For a 1-item legacy lease (no `service_name` set), pass `""` for `service-name`.
+Multi-item legacy leases cannot use custom_domain — recreate the lease in
+service-name mode.
+
+- Syntax: `manifestd tx billing set-item-custom-domain [lease-uuid] [service-name] [domain] [flags]`
+
+  - Parameters:
+    - `lease-uuid`: UUID of the lease
+    - `service-name`: Service name on the targeted item (`""` for a 1-item legacy lease)
+    - `domain`: FQDN to set, or `""` to clear
+
+  **Example (1-item lease):** `manifestd tx billing set-item-custom-domain 01912345-6789-7abc-8def-0123456789ab "" app.example.com --from tenant`
+  **Example (multi-item):** `manifestd tx billing set-item-custom-domain 01912345-6789-7abc-8def-0123456789ab web app.example.com --from tenant`
+  **Example (clear):** `manifestd tx billing set-item-custom-domain 01912345-6789-7abc-8def-0123456789ab web "" --from tenant`
+
 ##### Update Params (update-params):
 
 - Syntax: `manifestd tx billing update-params [max-leases-per-tenant] [max-items-per-lease] [min-lease-duration] [max-pending-leases-per-tenant] [pending-timeout] [flags]`
@@ -537,6 +566,8 @@ The Billing module implements a credit-based leasing system for AI infrastructur
     - `max-pending-leases-per-tenant`: Maximum pending leases per tenant
     - `pending-timeout`: Pending lease timeout in seconds (60-86400)
   - Flags:
-    - `--allowed-list`: Comma-separated list of addresses allowed to create leases for tenants
+    - `--allowed-list`: Comma-separated list of addresses allowed to create leases for tenants. **Preserve-on-omit**: when the flag is not provided, the current on-chain value is queried and re-submitted unchanged. Pass an empty value (`--allowed-list=""`) to explicitly clear it.
+    - `--reserved-domain-suffixes`: Comma-separated list of reserved domain suffixes (each must begin with `.`). Used to gate `set-item-custom-domain`. Same **preserve-on-omit** semantics as `--allowed-list`.
 
-  **Example:** `manifestd tx billing update-params 100 20 3600 10 1800 --from authority`
+  **Example (numeric only, lists preserved):** `manifestd tx billing update-params 100 20 3600 10 1800 --from authority`
+  **Example (set reserved suffixes):** `manifestd tx billing update-params 100 20 3600 10 1800 --reserved-domain-suffixes ".manifest.network,.lifted.app" --from authority`

--- a/README.md
+++ b/README.md
@@ -80,7 +80,10 @@ manifestd query billing leases-by-tenant $(manifestd keys show <KEY> -a) --state
 manifestd query billing lease <LEASE_UUID>
 
 # 6. (Optional, v2.1.0+) Attach a custom domain to a lease item once it's PENDING or ACTIVE.
-manifestd tx billing set-item-custom-domain <LEASE_UUID> web app.example.com --from <KEY>
+#    The 2nd argument is the item's `service_name`. Use "" for a 1-item legacy lease
+#    (item.service_name == ""); use the actual service name for stack-mode leases.
+manifestd tx billing set-item-custom-domain <LEASE_UUID> "" app.example.com --from <KEY>          # 1-item legacy lease
+manifestd tx billing set-item-custom-domain <LEASE_UUID> web app.example.com --from <KEY>         # stack-mode, target the "web" item
 
 # 7. When you're done, close it. Final settlement transfers accrued charges to the provider.
 manifestd tx billing close-lease <LEASE_UUID> --reason "no longer needed" --from <KEY>

--- a/README.md
+++ b/README.md
@@ -18,12 +18,16 @@
 
 ## Overview
 
-The Manifest Network, built on the Cosmos SDK, is a blockchain tailored for decentralized AI infrastructure access. Initially employing a Proof of Authority (PoA) model it ensures a secure and efficient launch phase, with a trusted validator set managing consensus.
+The Manifest Network, built on the Cosmos SDK, is a blockchain tailored for decentralized AI infrastructure access. Two on-chain primitives — `x/sku` and `x/billing` — let providers list billable resources (compute SKUs) and let tenants fund credit accounts and lease those SKUs at locked-in per-second prices. Settlement is lazy: charges accrue continuously but only move tokens when a provider withdraws or a lease is closed.
 
-While PoA offers immediate stability and control, the Manifest Network aspires for greater decentralization. The future roadmap includes evolving towards a Proof of Stake (PoS) network, utilizing the underlying CometBft consensus mechanism inherent in the Cosmos SDK.
+The chain runs Proof of Authority (`x/poa`) consensus, with plans to evolve toward Proof of Stake on CometBFT.
 
 ## Table of Contents
 
+- [Quickstart](#quickstart) — by role
+  - [I want to run a node / become a validator](#i-want-to-run-a-node--become-a-validator)
+  - [I'm a tenant — buying compute](#im-a-tenant--buying-compute)
+  - [I'm a provider — selling compute](#im-a-provider--selling-compute)
 - [System Requirements](#system-requirements)
 - [Installation](#install--run)
 - [Testing](#testing)
@@ -32,6 +36,106 @@ While PoA offers immediate stability and control, the Manifest Network aspires f
 - [Validators](./network/manifest-1/POST_GENESIS.md)
 - [Contributing](./CONTRIBUTING.md)
 - [Security/Bug Reporting](./SECURITY.md)
+- [JavaScript / TypeScript SDK](#javascript--typescript-sdk)
+- [Frontend / Integrator Cookbook](./docs/FRONTEND.md)
+
+## Quickstart
+
+The chain has four primary audiences. Pick the path that matches what you're trying to do.
+
+### I want to run a node / become a validator
+
+Follow [POST_GENESIS.md](./network/manifest-1/POST_GENESIS.md) end-to-end — install, peers, state-sync/snapshots, systemd, and the PoA `create-validator` flow. Once running, see [UPGRADES.md](./network/manifest-1/UPGRADES.md) for the upgrade runbook.
+
+### I'm a tenant — buying compute
+
+You'll fund a **credit account** with tokens, then create **leases** against published SKUs. Charges accrue per-second against your credit; the provider withdraws as the lease runs.
+
+```bash
+# 0. Point the CLI at manifest-1 and pick your key. <KEY> is anything in `manifestd keys list`.
+manifestd config set client chain-id manifest-1
+manifestd config set client node https://rpc.example.org:443     # see chain-registry / Discord
+
+# 1. Discover providers and active SKUs.
+manifestd query sku providers --active-only
+manifestd query sku skus --active-only
+# Or all SKUs from one provider:
+manifestd query sku skus-by-provider <PROVIDER_UUID>
+
+# 2. Fund your own credit account. Anyone can fund any tenant — most often you fund yourself.
+#    Match the denom to whatever the target SKU prices in (`base_price.denom`).
+manifestd tx billing fund-credit $(manifestd keys show <KEY> -a) 1000000upwr --from <KEY>
+
+# 3. Confirm the credit is reserved-aware (available_balances = balances - reserved_amounts).
+manifestd query billing credit-account $(manifestd keys show <KEY> -a)
+
+# 4. Create a lease. Format is sku_uuid:quantity[:service_name]; multiple items must share one provider.
+manifestd tx billing create-lease <SKU_UUID>:1 --from <KEY>
+# Stack deployment with named services:
+manifestd tx billing create-lease <SKU_UUID>:1:web <SKU_UUID>:1:db --from <KEY>
+
+# 5. Wait for the provider to acknowledge. Until then the lease is PENDING and can be cancelled.
+manifestd query billing leases-by-tenant $(manifestd keys show <KEY> -a) --state pending
+manifestd query billing lease <LEASE_UUID>
+
+# 6. (Optional, v2.1.0+) Attach a custom domain to a lease item once it's PENDING or ACTIVE.
+manifestd tx billing set-item-custom-domain <LEASE_UUID> web app.example.com --from <KEY>
+
+# 7. When you're done, close it. Final settlement transfers accrued charges to the provider.
+manifestd tx billing close-lease <LEASE_UUID> --reason "no longer needed" --from <KEY>
+```
+
+If you're building a wallet or dashboard rather than driving the CLI, use [`@manifest-network/manifestjs`](#javascript--typescript-sdk) — every message and query above has a generated TypeScript counterpart. The end-to-end cookbook lives at [`docs/FRONTEND.md`](./docs/FRONTEND.md).
+
+**Deeper reading:** [`x/billing/README.md`](./x/billing/README.md), [`x/billing/docs/API.md`](./x/billing/docs/API.md), [`x/billing/docs/INTEGRATION.md`](./x/billing/docs/INTEGRATION.md) (provider authentication / ADR-036 sign-in flow).
+
+### I'm a provider — selling compute
+
+Provider registration is **authority-controlled** on `manifest-1`: you cannot self-register. Coordinate with the authority (or a member of `params.allowed_list`) to provision your provider record and SKUs. Once you're set up, your day-to-day flow is acknowledging, withdrawing, and closing.
+
+**One-time setup (run by the authority on your behalf):**
+
+```bash
+# 1. Authority creates your provider record with your operator address and a payout address.
+manifestd tx sku create-provider <YOUR_OP_ADDR> <YOUR_PAYOUT_ADDR> \
+  --api-url https://api.your-provider.example \
+  --from authority
+
+# 2. Authority creates a SKU under your provider. unit: 1=hour, 2=day. Price is per unit.
+manifestd tx sku create-sku <PROVIDER_UUID> "GPU Instance — A100 40GB" 1 3600upwr --from authority
+```
+
+Note your `PROVIDER_UUID` and each `SKU_UUID` from the events / response — they're how tenants will address you.
+
+**Steady-state (you run these):**
+
+```bash
+# 3. Watch for pending leases against your provider. Filter by state, or subscribe to the
+#    chain's CometBFT websocket on `lease_created` events for push-style notifications.
+manifestd query billing leases-by-provider <PROVIDER_UUID> --state pending
+
+# 4. Acknowledge (transitions PENDING → ACTIVE; billing starts now). Reject if you can't fulfil.
+manifestd tx billing acknowledge-lease <LEASE_UUID> --from <PROVIDER_KEY>
+manifestd tx billing reject-lease    <LEASE_UUID> --reason "out of capacity" --from <PROVIDER_KEY>
+
+# 5. Provision off-chain. Tenants authenticate to your API per docs/INTEGRATION.md (ADR-036).
+
+# 6. Withdraw accrued credit. Two modes: specific lease(s), or paginated provider-wide.
+manifestd tx billing withdraw <LEASE_UUID> --from <PROVIDER_KEY>
+manifestd tx billing withdraw --provider <PROVIDER_UUID> --limit 100 --from <PROVIDER_KEY>
+# Provider-wide mode pages — repeat while `has_more: true` in the response.
+
+# 7. Check what's currently withdrawable without claiming it:
+manifestd query billing provider-withdrawable <PROVIDER_UUID>
+manifestd query billing withdrawable <LEASE_UUID>
+
+# 8. Close a lease when service ends (provider, tenant, or authority can close ACTIVE leases):
+manifestd tx billing close-lease <LEASE_UUID> --reason "service ended" --from <PROVIDER_KEY>
+```
+
+**Auto-close behaviour:** if a tenant's credit runs out, the next `withdraw` or `close-lease` against the lease performs the final settlement (against whatever balance remains) and auto-closes it. You don't need to poll.
+
+**Deeper reading:** [`x/sku/docs/PROVIDER_GUIDE.md`](./x/sku/docs/PROVIDER_GUIDE.md), [`x/sku/docs/SKU_GUIDE.md`](./x/sku/docs/SKU_GUIDE.md), [`x/billing/docs/INTEGRATION.md`](./x/billing/docs/INTEGRATION.md).
 
 ## System Requirements
 
@@ -182,6 +286,18 @@ To generate a coverage report for the modules run:
 make local-image
 make coverage
 ```
+
+## JavaScript / TypeScript SDK
+
+For frontend, wallet, dashboard, and explorer integrations, use [`@manifest-network/manifestjs`](https://github.com/manifest-network/manifestjs) — a generated TypeScript client covering all chain modules (`x/manifest`, `x/sku`, `x/billing`, `x/poa`, `x/tokenfactory`, `x/wasm`, IBC) plus the standard Cosmos SDK modules.
+
+```bash
+npm install @manifest-network/manifestjs
+```
+
+The package is regenerated from this repo's `proto/liftedinit/**/*.proto` definitions, so message names, field types, and signatures stay in lock-step with on-chain types. See the `manifestjs` repo for usage examples and the published types under `liftedinit.{manifest,sku,billing}.v1`.
+
+For end-to-end recipes — query client, signing client, Keplr/Leap integration, message composition, websocket subscriptions, and the type-URL / amino-name reference — read [`docs/FRONTEND.md`](./docs/FRONTEND.md).
 
 ## Helper
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The chain runs Proof of Authority (`x/poa`) consensus, with plans to evolve towa
   - [I want to run a node / become a validator](#i-want-to-run-a-node--become-a-validator)
   - [I'm a tenant — buying compute](#im-a-tenant--buying-compute)
   - [I'm a provider — selling compute](#im-a-provider--selling-compute)
+  - [I'm a wallet / frontend integrator](#im-a-wallet--frontend-integrator)
 - [System Requirements](#system-requirements)
 - [Installation](#install--run)
 - [Testing](#testing)
@@ -136,6 +137,10 @@ manifestd tx billing close-lease <LEASE_UUID> --reason "service ended" --from <P
 **Auto-close behaviour:** if a tenant's credit runs out, the next `withdraw` or `close-lease` against the lease performs the final settlement (against whatever balance remains) and auto-closes it. You don't need to poll.
 
 **Deeper reading:** [`x/sku/docs/PROVIDER_GUIDE.md`](./x/sku/docs/PROVIDER_GUIDE.md), [`x/sku/docs/SKU_GUIDE.md`](./x/sku/docs/SKU_GUIDE.md), [`x/billing/docs/INTEGRATION.md`](./x/billing/docs/INTEGRATION.md).
+
+### I'm a wallet / frontend integrator
+
+Use [`@manifest-network/manifestjs`](#javascript--typescript-sdk) — a generated TypeScript client whose `liftedinit.{billing,sku,manifest}.v1` namespaces cover every message and query above (and stay in lock-step with this repo's protos). End-to-end recipes for Keplr/Leap signing, message composition, query patterns, websocket event subscriptions, and the type-URL / amino-name reference live in [`docs/FRONTEND.md`](./docs/FRONTEND.md).
 
 ## System Requirements
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,25 +1,17 @@
 # Security
 
-#TODO: add PGP KEY
-
-> **🚨IMPORTANT🚨**: If you find a security issue, please report it to our [security mailing list](mailto:security@manifest.network) _PLEASE DO NOT_ create a public issue.
+> **🚨 IMPORTANT 🚨** — if you find a security issue, report it privately to <security@manifest.network>. **Do not** open a public GitHub issue.
 
 ## Reporting
 
-Please report to our security mailing list at [security@manifest.network
-](mailto:security@manifest.network) and we shall respond to you within 72 hours.
+Send a report to [security@manifest.network](mailto:security@manifest.network). We aim to respond within 72 hours.
 
-###
-
-If you want to send us encrypted data, our GPG Public key is below. [Here](https://www.gnupg.org/gph/en/manual/x110.html) are instructions on how to do it.
-
-```
------BEGIN PGP PUBLIC KEY BLOCK-----
-
-
------END PGP PUBLIC KEY BLOCK----
-```
+If you need to send encrypted material, request our current GPG public key by email first — we issue keys per-disclosure rather than publishing a long-lived key here, so the contents and the channel match each report.
 
 ## Packages in scope
 
 - [x/manifest](/x/manifest)
+- [x/sku](/x/sku)
+- [x/billing](/x/billing)
+- [pkg/uuid](/pkg/uuid)
+- [app](/app)

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -1,0 +1,467 @@
+# Frontend / Integrator Cookbook
+
+This guide is for anyone building a wallet, dashboard, explorer, or off-chain service on top of `manifest-1`. Every recipe uses [`@manifest-network/manifestjs`](https://github.com/manifest-network/manifestjs) — the canonical TypeScript client generated from this repo's protos.
+
+> **Why manifestjs and not raw CosmJS?** Raw CosmJS works but you'd have to register the `liftedinit.{billing,sku,manifest}.v1` types yourself and translate every message. manifestjs ships pre-registered protobuf types, amino converters (for Keplr/Leap signing of the chain's custom messages), and a typed query client. Stay on it unless you have a reason not to.
+
+## Audience
+
+Pick the section that matches what you're building:
+
+| You are… | Read |
+|---|---|
+| A wallet that needs to sign chain-native messages | [Install](#install) → [Signing client](#signing-client-write-path) → [Tenant recipes](#tenant-recipes) |
+| A tenant dashboard | [Install](#install) → [Query client](#query-client-read-path) → [Tenant recipes](#tenant-recipes) → [Subscribing to events](#subscribing-to-chain-events) |
+| A provider control plane | [Install](#install) → [Provider recipes](#provider-recipes) → [Tenant authentication (ADR-036)](#tenant-authentication-to-your-provider-api) |
+| An explorer / indexer | [Install](#install) → [Query client](#query-client-read-path) → [Subscribing to events](#subscribing-to-chain-events) → [Type URL / amino reference](#type-url--amino-name-reference) |
+
+## Install
+
+```bash
+npm install @manifest-network/manifestjs
+# Peer deps (commonly already present in a CosmJS app):
+npm install @cosmjs/proto-signing @cosmjs/stargate @cosmjs/tendermint-rpc
+```
+
+manifestjs is a pure-codegen package — its semver tracks the proto surface, not chain releases. As of writing, mainnet runs `v2.1.0` of the chain and the matching client is `@manifest-network/manifestjs@^2.4`.
+
+## Query client (read path)
+
+For read-only state, use `createRPCQueryClient`. It returns a typed object covering every module on the chain (`cosmos.*`, `ibc.*`, `cosmwasm.*`, `osmosis.tokenfactory.*`, `strangelove_ventures.poa.*`, and `liftedinit.{billing,sku,manifest}.v1`).
+
+```ts
+import { createRPCQueryClient } from "@manifest-network/manifestjs";
+
+const client = await createRPCQueryClient({
+  rpcEndpoint: "https://rpc.example.org:443",   // see chain-registry / Discord
+});
+
+// Bank balance — same as any CosmJS app:
+const balance = await client.cosmos.bank.v1beta1.balance({
+  address: "manifest1...",
+  denom: "umfx",
+});
+
+// Manifest-specific reads:
+const lease = await client.liftedinit.billing.v1.lease({
+  leaseUuid: "01902a9b-1234-7000-8000-000000000001",
+});
+
+const credit = await client.liftedinit.billing.v1.creditAccount({
+  tenant: "manifest1...",
+});
+// credit.balances           — bank balances at the credit address
+// credit.availableBalances  — balances - reserved_amounts (what new leases can use)
+// credit.creditAccount.reservedAmounts — locked by PENDING/ACTIVE leases
+```
+
+Prefer `createLCDQueryClient` if you need to hit the REST gateway instead of CometBFT RPC (e.g. browser sandboxes that can't open a WS):
+
+```ts
+import { createLCDClient } from "@manifest-network/manifestjs";
+
+const lcd = await createLCDClient({ restEndpoint: "https://api.example.org" });
+const params = await lcd.liftedinit.billing.v1.params();
+```
+
+## Signing client (write path)
+
+For transactions, build a `SigningStargateClient` pre-loaded with the chain's protobuf registry and amino converters. manifestjs provides a one-call helper:
+
+```ts
+import { getSigningLiftedinitClient } from "@manifest-network/manifestjs";
+
+// signer: any OfflineSigner — Keplr, Leap, a Web3Auth signer, or a local DirectSecp256k1HdWallet
+const signingClient = await getSigningLiftedinitClient({
+  rpcEndpoint: "https://rpc.example.org:443",
+  signer,
+});
+```
+
+If you already manage a `SigningStargateClient` yourself (because you also need `cosmwasm` exec messages, or custom client options), grab the registry and amino types separately and merge them into your own client:
+
+```ts
+import {
+  getSigningLiftedinitClientOptions,
+  liftedinitProtoRegistry,
+  liftedinitAminoConverters,
+} from "@manifest-network/manifestjs";
+
+const { registry, aminoTypes } = getSigningLiftedinitClientOptions();
+// or compose with other modules:
+const myRegistry = new Registry([
+  ...defaultRegistryTypes,
+  ...wasmTypes,
+  ...liftedinitProtoRegistry,
+]);
+const myAminoTypes = new AminoTypes({
+  ...createWasmAminoConverters(),
+  ...liftedinitAminoConverters,
+});
+```
+
+### Browser wallets (Keplr / Leap)
+
+Both Keplr and Leap implement `getOfflineSignerAuto(chainId)` (or `getOfflineSigner(chainId)`). For Ledger-backed accounts, use `getOfflineSignerOnlyAmino(chainId)` — the amino converters above make the chain's custom messages signable on Ledger.
+
+```ts
+await window.keplr.enable("manifest-1");
+const signer = window.keplr.getOfflineSignerAuto
+  ? await window.keplr.getOfflineSignerAuto("manifest-1")
+  : window.keplr.getOfflineSigner("manifest-1");
+
+const [{ address: tenant }] = await signer.getAccounts();
+```
+
+Make sure your suggestion to `experimentalSuggestChain` lists `umfx` (and any factory-token your dApp uses) under `currencies` and `feeCurrencies` so Keplr renders amounts correctly.
+
+### Programmatic / server-side
+
+For backend services or tests, use a local mnemonic-backed signer:
+
+```ts
+import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
+
+const signer = await DirectSecp256k1HdWallet.fromMnemonic(MNEMONIC, {
+  prefix: "manifest",
+});
+```
+
+## Tenant recipes
+
+Two equivalent patterns sit on top of the registry:
+- **`MessageComposer.encoded.<msgName>(value)`** — returns a `{ typeUrl, value }` ready for `signAndBroadcast`. Use this when you want to bundle multiple messages in one tx.
+- **Module RPC clients** — `client.liftedinit.billing.v1.fundCredit(...)` etc. Use this when you're sending one message and want a typed response.
+
+Either way you end up sending the same on-chain message.
+
+### Fund a tenant's credit account (`MsgFundCredit`)
+
+```ts
+import { liftedinit } from "@manifest-network/manifestjs";
+
+const fundCredit = liftedinit.billing.v1.MessageComposer.encoded.fundCredit({
+  sender: tenant,
+  tenant,                                      // can be anyone — funding someone else is fine
+  amount: { denom: "upwr", amount: "1000000" },
+});
+
+const fee = "auto";                            // or { amount: [{ denom: "umfx", amount: "5000" }], gas: "200000" }
+const res = await signingClient.signAndBroadcast(tenant, [fundCredit], fee, "fund my credit");
+console.log("tx hash:", res.transactionHash);
+```
+
+`MsgFundCreditResponse` carries `creditAddress` and `newBalance` — decode the response from `res.msgResponses[0]` if you need them.
+
+### Create a lease (`MsgCreateLease`)
+
+A lease is one or more `LeaseItemInput`s. All items must belong to the same provider. `serviceName` is optional but **all-or-nothing per lease**: if any item sets it, every item must.
+
+```ts
+import { liftedinit } from "@manifest-network/manifestjs";
+
+// Single-item legacy lease:
+const create = liftedinit.billing.v1.MessageComposer.encoded.createLease({
+  tenant,
+  items: [
+    { skuUuid: "01912345-...-0123456789ab", quantity: 1n, serviceName: "" },
+  ],
+  metaHash: new Uint8Array(),                  // optional, ≤ 64 bytes
+});
+
+// Stack-mode (same SKU twice with different services):
+const stack = liftedinit.billing.v1.MessageComposer.encoded.createLease({
+  tenant,
+  items: [
+    { skuUuid: "01912345-...-aaaa", quantity: 1n, serviceName: "web" },
+    { skuUuid: "01912345-...-aaaa", quantity: 1n, serviceName: "db"  },
+  ],
+  metaHash: hexToBytes("a1b2c3..."),           // hash of off-chain deployment manifest
+});
+
+const res = await signingClient.signAndBroadcast(tenant, [create], "auto");
+// MsgCreateLeaseResponse.lease_uuid identifies the new lease (also surfaced in the `lease_created` event).
+```
+
+> `quantity` is a `bigint` because protobuf `uint64` deserialises to `BigInt` in JS. If you accept user input, parse with `BigInt(input)` rather than `Number()`.
+
+### Set or clear a custom domain (`MsgSetItemCustomDomain`, v2.1.0+)
+
+Mutates `LeaseItem.custom_domain` after creation. Sender must be the tenant, the module authority, or an address in `params.allowed_list`. The lease must be PENDING or ACTIVE.
+
+```ts
+const setDomain = liftedinit.billing.v1.MessageComposer.encoded.setItemCustomDomain({
+  sender: tenant,
+  leaseUuid: lease,
+  serviceName: "web",                          // pass "" for a 1-item legacy lease
+  customDomain: "app.example.com",
+});
+
+await signingClient.signAndBroadcast(tenant, [setDomain], "auto");
+
+// Clear it:
+const clear = liftedinit.billing.v1.MessageComposer.encoded.setItemCustomDomain({
+  sender: tenant,
+  leaseUuid: lease,
+  serviceName: "web",
+  customDomain: "",                            // empty string clears
+});
+```
+
+The keeper lower-cases and trims `customDomain` before validation, so callers may submit mixed case. See [`x/billing/docs/API.md`](../x/billing/docs/API.md#set-item-custom-domain) for the full FQDN rules and reserved-suffix behaviour.
+
+### Cancel a pending lease (`MsgCancelLease`)
+
+```ts
+const cancel = liftedinit.billing.v1.MessageComposer.encoded.cancelLease({
+  tenant,
+  leaseUuids: [lease],                         // 1–100 leases, all must be your own PENDING leases
+});
+await signingClient.signAndBroadcast(tenant, [cancel], "auto");
+```
+
+### Close an active lease (`MsgCloseLease`)
+
+Tenant, provider, or authority can close. Final settlement happens at close.
+
+```ts
+const close = liftedinit.billing.v1.MessageComposer.encoded.closeLease({
+  sender: tenant,
+  leaseUuids: [lease],
+  reason: "service no longer needed",          // ≤ 256 chars, applied to all
+});
+await signingClient.signAndBroadcast(tenant, [close], "auto");
+```
+
+## Provider recipes
+
+### Acknowledge or reject (`MsgAcknowledgeLease` / `MsgRejectLease`)
+
+```ts
+const ack = liftedinit.billing.v1.MessageComposer.encoded.acknowledgeLease({
+  sender: providerKey,
+  leaseUuids: [lease],                         // batch up to 100; same provider; atomic
+});
+await signingClient.signAndBroadcast(providerKey, [ack], "auto");
+
+// Or reject with a reason:
+const reject = liftedinit.billing.v1.MessageComposer.encoded.rejectLease({
+  sender: providerKey,
+  leaseUuids: [lease],
+  reason: "out of capacity",
+});
+```
+
+### Withdraw (`MsgWithdraw`)
+
+Two mutually-exclusive modes. Specific-leases mode is atomic across the batch; provider-wide mode is paginated.
+
+```ts
+// Mode 1 — specific leases (1-100):
+const withdraw = liftedinit.billing.v1.MessageComposer.encoded.withdraw({
+  sender: providerKey,
+  leaseUuids: [lease1, lease2],
+  providerUuid: "",
+  limit: 0n,
+});
+
+// Mode 2 — provider-wide (paginated):
+async function withdrawAll(providerUuid: string) {
+  while (true) {
+    const msg = liftedinit.billing.v1.MessageComposer.encoded.withdraw({
+      sender: providerKey,
+      leaseUuids: [],
+      providerUuid,
+      limit: 100n,                             // max 100; 0 = default 50
+    });
+    const res = await signingClient.signAndBroadcast(providerKey, [msg], "auto");
+    const decoded = liftedinit.billing.v1.MsgWithdrawResponse.decode(res.msgResponses[0].value);
+    if (!decoded.hasMore) return;              // stop when chain says no more
+  }
+}
+```
+
+Read-only "what would I withdraw" estimates:
+
+```ts
+const perLease = await client.liftedinit.billing.v1.withdrawableAmount({ leaseUuid });
+const provider = await client.liftedinit.billing.v1.providerWithdrawable({
+  providerUuid,
+  limit: 100n,
+});
+// provider.amounts (per-denom totals), provider.leaseCount, provider.hasMore
+```
+
+### Tenant authentication to your provider API
+
+After a lease goes ACTIVE, tenants prove ownership using ADR-036 arbitrary-message signing. The full message format, validation steps, and sample verifier code live in [`x/billing/docs/INTEGRATION.md`](../x/billing/docs/INTEGRATION.md). Frontend side, the call is:
+
+```ts
+const message = `manifest lease access ${leaseUuid} ${Math.floor(Date.now() / 1000)}`;
+const sig = await window.keplr.signArbitrary("manifest-1", tenant, message);
+// POST { tenant, lease_uuid, timestamp, pub_key: sig.pub_key, signature: sig.signature }
+//   to {provider.api_url}/v1/leases/{lease_uuid}/connection
+```
+
+Use the same recipe with Leap (`window.leap.signArbitrary(...)`) — the API is identical. Web3Auth-derived signers reach this through `OfflineAminoSigner.signAmino`.
+
+## Querying state — common patterns
+
+### Filter leases by state
+
+`stateFilter` is a `LeaseState` enum value, exposed under the chain's bundle namespace. `LEASE_STATE_UNSPECIFIED (0)` returns everything.
+
+```ts
+import { liftedinit } from "@manifest-network/manifestjs";
+
+const pending = await client.liftedinit.billing.v1.leasesByTenant({
+  tenant,
+  pagination: undefined,
+  stateFilter: liftedinit.billing.v1.LeaseState.LEASE_STATE_PENDING,
+});
+
+const active = await client.liftedinit.billing.v1.leasesByProvider({
+  providerUuid,
+  pagination: undefined,
+  stateFilter: liftedinit.billing.v1.LeaseState.LEASE_STATE_ACTIVE,
+});
+```
+
+### Look up a lease by domain (v2.1.0+)
+
+```ts
+const { lease, serviceName } = await client.liftedinit.billing.v1.leaseByCustomDomain({
+  customDomain: "app.example.com",             // case-insensitive; chain lower-cases on lookup
+});
+// throws if no PENDING/ACTIVE lease has claimed it.
+```
+
+### Pagination
+
+All `Query.<list>` queries take a Cosmos `PageRequest`. Use `key` for stable cursoring across pages.
+
+```ts
+import { cosmos, liftedinit } from "@manifest-network/manifestjs";
+
+let key: Uint8Array | undefined;
+do {
+  const { leases, pagination } = await client.liftedinit.billing.v1.leases({
+    pagination: cosmos.base.query.v1beta1.PageRequest.fromPartial({ key, limit: 100n }),
+    stateFilter: liftedinit.billing.v1.LeaseState.LEASE_STATE_ACTIVE,
+  });
+  for (const l of leases) handle(l);
+  key = pagination?.nextKey;
+} while (key && key.length > 0);
+```
+
+> Don't import `PageRequest` from the package root — telescope exposes an unrelated helper of the same name there. Always go through `cosmos.base.query.v1beta1`.
+
+### Discover providers and SKUs
+
+```ts
+const providers = await client.liftedinit.sku.v1.providers({
+  activeOnly: true,
+  pagination: undefined,
+});
+
+const skus = await client.liftedinit.sku.v1.sKUsByProvider({
+  providerUuid,
+  activeOnly: true,
+  pagination: undefined,
+});
+// SKU.unit is a Unit enum: UNIT_PER_HOUR (1) or UNIT_PER_DAY (2).
+// SKU.basePrice is the price per unit; per-second rate = base_price / 3600 (hour) or / 86400 (day).
+```
+
+> Note the camelCase: telescope-generated rpc methods are camelCased, but the all-caps `SKU` becomes `sKUs...`. If your editor's autocomplete struggles, search for `sKU` or use the typed module bundle (`liftedinit.sku.v1`).
+
+## Subscribing to chain events
+
+For push-style reactivity (e.g. provider notification on `lease_created`), open a CometBFT websocket. Custom event types from `x/billing` are emitted as standard ABCI events and queryable via `tm.event='Tx'` plus an attribute filter.
+
+```ts
+import { connectComet } from "@cosmjs/tendermint-rpc";
+
+const tm = await connectComet("wss://rpc.example.org/websocket");
+
+const sub = tm.subscribeTx(
+  // Tendermint query syntax — match any transaction emitting a `lease_created` event for our provider:
+  `lease_created.provider_uuid='${providerUuid}'`,
+);
+
+(async () => {
+  for await (const tx of sub) {
+    const ev = tx.result.events.find(e => e.type === "lease_created");
+    const leaseUuid = ev?.attributes.find(a => a.key === "lease_uuid")?.value;
+    onPendingLease(leaseUuid!);
+  }
+})();
+```
+
+Common subscriptions for a provider control plane:
+
+| Goal | Subscription query |
+|---|---|
+| New pending leases for me | `lease_created.provider_uuid='<UUID>'` |
+| Tenants cancelling pending leases | `lease_cancelled.provider_uuid='<UUID>'` |
+| Auto-close on credit exhaustion | `lease_auto_closed.provider_uuid='<UUID>'` |
+| Domain set / cleared on my leases | `lease_custom_domain_set.tenant EXISTS` (filter further client-side; v2.1.0+) |
+
+The full event catalogue and attributes live in [`x/billing/docs/API.md#events`](../x/billing/docs/API.md#events).
+
+## Type URL / amino name reference
+
+manifestjs registers all of the following automatically. You only need this table when you're talking to a wallet that wants the type URL by string (e.g. `signer.signDirect` payloads) or building a low-level transaction by hand.
+
+### x/billing
+
+| Type URL | Amino name |
+|---|---|
+| `/liftedinit.billing.v1.MsgFundCredit` | `lifted/billing/MsgFundCredit` |
+| `/liftedinit.billing.v1.MsgCreateLease` | `lifted/billing/MsgCreateLease` |
+| `/liftedinit.billing.v1.MsgCreateLeaseForTenant` | `lifted/billing/MsgCreateLeaseForTenant` |
+| `/liftedinit.billing.v1.MsgAcknowledgeLease` | `lifted/billing/MsgAcknowledgeLease` |
+| `/liftedinit.billing.v1.MsgRejectLease` | `lifted/billing/MsgRejectLease` |
+| `/liftedinit.billing.v1.MsgCancelLease` | `lifted/billing/MsgCancelLease` |
+| `/liftedinit.billing.v1.MsgCloseLease` | `lifted/billing/MsgCloseLease` |
+| `/liftedinit.billing.v1.MsgWithdraw` | `lifted/billing/MsgWithdraw` |
+| `/liftedinit.billing.v1.MsgSetItemCustomDomain` | `lifted/billing/MsgSetItemCustomDomain` |
+| `/liftedinit.billing.v1.MsgUpdateParams` | `lifted/billing/MsgUpdateParams` |
+
+### x/sku
+
+| Type URL | Amino name |
+|---|---|
+| `/liftedinit.sku.v1.MsgCreateProvider` | `lifted/sku/MsgCreateProvider` |
+| `/liftedinit.sku.v1.MsgUpdateProvider` | `lifted/sku/MsgUpdateProvider` |
+| `/liftedinit.sku.v1.MsgDeactivateProvider` | `lifted/sku/MsgDeactivateProvider` |
+| `/liftedinit.sku.v1.MsgCreateSKU` | `lifted/sku/MsgCreateSKU` |
+| `/liftedinit.sku.v1.MsgUpdateSKU` | `lifted/sku/MsgUpdateSKU` |
+| `/liftedinit.sku.v1.MsgDeactivateSKU` | `lifted/sku/MsgDeactivateSKU` |
+| `/liftedinit.sku.v1.MsgUpdateParams` | `lifted/sku/MsgUpdateParams` |
+
+### x/manifest
+
+| Type URL | Amino name |
+|---|---|
+| `/liftedinit.manifest.v1.MsgPayout` | `lifted/manifest/MsgPayout` |
+| `/liftedinit.manifest.v1.MsgBurnHeldBalance` | `lifted/manifest/MsgBurnHeldBalance` |
+
+`PayoutPair` (carried inside `MsgPayout`) has the amino name `lifted/manifest/payout-pair`.
+
+## Tips
+
+- **`uint64` is a `bigint`.** Telescope generates `bigint` for `uint64` (e.g. `quantity`, `limit`, `pendingTimeout`). Always parse user input with `BigInt(...)` and serialise with `.toString()` — `JSON.stringify` does not handle bigints natively.
+- **`bytes` is a `Uint8Array`.** `metaHash` and event-attribute byte values are not hex-encoded for you. Use `bytesFromBase64` / `base64FromBytes` from the package's helpers, or hex utilities from your bundler.
+- **Coin denoms.** Mainnet's gas/fee denom is `umfx`; the staking denom is `upoa`. Tenant credit accounts can hold *any* denom that matches a SKU's `basePrice.denom` — typically a TokenFactory-issued credit token (e.g. `factory/manifest1.../upwr`).
+- **`MsgUpdateParams` is replace-style.** When wiring a governance dApp, query the current params first and merge your delta in — sending an unset list field will clear it. (The CLI implements PRESERVE-on-omit; the bare protobuf message does not.)
+- **Don't construct credit addresses yourself.** `Query.creditAddress({ tenant })` returns the deterministic derived address. The derivation rule may evolve; the query won't.
+- **Decoding `msgResponses`.** A successful `signAndBroadcast` populates `res.msgResponses` with raw protobuf bytes. To read structured response fields, decode with the matching response type: `MsgCreateLeaseResponse.decode(res.msgResponses[0].value)`.
+
+## Related documentation
+
+- Module APIs: [`x/billing/docs/API.md`](../x/billing/docs/API.md), [`x/sku/docs/API.md`](../x/sku/docs/API.md)
+- Provider tenant-auth: [`x/billing/docs/INTEGRATION.md`](../x/billing/docs/INTEGRATION.md)
+- Module concepts: [`x/billing/README.md`](../x/billing/README.md), [`x/sku/README.md`](../x/sku/README.md)
+- Top-level chain overview: [`README.md`](../README.md)
+- manifestjs source / issues: <https://github.com/manifest-network/manifestjs>

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -208,7 +208,7 @@ const clear = liftedinit.billing.v1.MessageComposer.encoded.setItemCustomDomain(
 });
 ```
 
-The keeper lower-cases and trims `customDomain` before validation, so callers may submit mixed case. See [`x/billing/docs/API.md`](../x/billing/docs/API.md#set-item-custom-domain) for the full FQDN rules and reserved-suffix behaviour.
+**Lower-case `customDomain` client-side before signing** — `MsgSetItemCustomDomain.ValidateBasic()` rejects mixed case (it calls `IsValidFQDN` directly), so the tx fails before reaching the keeper. The keeper does its own `strings.ToLower(strings.TrimSpace(...))` as defence-in-depth, but you can't rely on it as a normalisation point for input. See [`x/billing/docs/API.md`](../x/billing/docs/API.md#set-item-custom-domain) for the full FQDN rules and reserved-suffix behaviour.
 
 ### Cancel a pending lease (`MsgCancelLease`)
 

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -55,7 +55,7 @@ const credit = await client.liftedinit.billing.v1.creditAccount({
 // credit.creditAccount.reservedAmounts — locked by PENDING/ACTIVE leases
 ```
 
-Prefer `createLCDQueryClient` if you need to hit the REST gateway instead of CometBFT RPC (e.g. browser sandboxes that can't open a WS):
+Prefer `createLCDClient` if you need to hit the REST gateway instead of CometBFT RPC (e.g. browser sandboxes that can't open a WS):
 
 ```ts
 import { createLCDClient } from "@manifest-network/manifestjs";

--- a/network/manifest-1/GENESIS.md
+++ b/network/manifest-1/GENESIS.md
@@ -1,11 +1,10 @@
 # Mainnet Genesis
 
-TODO:
+This document describes the genesis-ceremony flow for validators participating in the **initial** chain launch — i.e., signing a gentx that goes into the canonical `manifest-1_genesis.json` before the chain produces its first block. Mainnet has been live since 2024-04-10, so unless you are bootstrapping a new chain or testnet from this repository's `set-genesis-params.sh`, follow [POST_GENESIS.md](./POST_GENESIS.md) instead.
 
-- Update PoA Admin(s) from manifest10d07y265gmmuvt4z0w9aw880jnsr700jmq3jzm
-- Remove manifest1hj5fveer5cjtn4wd6wstzugjfdxzl0xp8ws9ct once others are given genesis allocations
+> The frozen mainnet genesis file is checked in at [`manifest-1_genesis.json`](./manifest-1_genesis.json). Post-genesis joiners download that file directly — they do **not** run the gentx flow below.
 
-# Post Genesis Validators
+## Post Genesis Validators
 
 If you are a validator joining the network after the initial genesis launch, follow the [post genesis document here](./POST_GENESIS.md).
 
@@ -25,7 +24,7 @@ If you are a validator joining the network after the initial genesis launch, fol
 
 **Operating System**
 
-- Linux (x86_64) or Linux (amd64)
+- Linux (x86_64 with SSSE3) or Linux (arm64 with NEON). CosmWasm requires SSSE3 / NEON — older CPUs will not run the binary.
 
 ### Dependencies
 
@@ -89,21 +88,23 @@ PROJECT_HOME="${HOME}/.manifest"
 KEYNAME_ADDR=$(manifestd keys show $KEYNAME -a)
 
 # Remove old files if they exist and replace genesis.json
-manifestd tendermint unsafe-reset-all
+manifestd comet unsafe-reset-all
 rm $HOME/.manifest/config/genesis.json
 rm $HOME/.manifest/config/gentx/*.json
-wget https://raw.githubusercontent.com/liftedinit/manifest-ledger/main/network/manifest-1/genesis.json -O $HOME/.manifest/config/genesis.json
+wget https://raw.githubusercontent.com/manifest-network/manifest-ledger/main/network/manifest-1/manifest-1_genesis.json -O $HOME/.manifest/config/genesis.json
 
-# Give yourself 1POASTAKE for the genesis Tx signed
-manifestd init "$MONIKER" --chain-id $CHAIN_ID --staking-bond-denom upoa
-manifestd add-genesis-account $KEYNAME_ADDR 1000000upoa
+# Give yourself 1POASTAKE for the genesis Tx signed.
+# --default-denom (umfx) controls the local fee/gas denom; --staking-bond-denom (upoa)
+# is the staking denom that must match the genesis app_state.staking.params.bond_denom.
+manifestd init "$MONIKER" --chain-id $CHAIN_ID --default-denom umfx --staking-bond-denom upoa
+manifestd genesis add-genesis-account $KEYNAME_ADDR 1000000upoa
 
 # genesis transaction using all above variables
-manifestd gentx $KEYNAME 1000000upoa \
+manifestd genesis gentx $KEYNAME 1000000upoa \
     --home=$PROJECT_HOME \
     --chain-id=$CHAIN_ID \
     --moniker="$MONIKER" \
-     --commission-max-change-rate=$MAX_CHANGE \
+    --commission-max-change-rate=$MAX_CHANGE \
     --commission-max-rate=$MAX_RATE \
     --commission-rate=$COMMISSION_RATE \
     --security-contact=$SECURITY_CONTACT \
@@ -114,7 +115,7 @@ manifestd gentx $KEYNAME 1000000upoa \
 cat ${PROJECT_HOME}/config/gentx/gentx-*.json
 
 # get your peer
-echo $(manifestd tendermint show-node-id)@$(curl -s ifconfig.me):26656`
+echo $(manifestd comet show-node-id)@$(curl -s ifconfig.me):26656
 ```
 
 > Update minimum gas prices
@@ -126,7 +127,7 @@ sed -i 's/minimum-gas-prices = "0stake"/minimum-gas-prices = "0umfx"/g' ${HOME}/
 
 ## Collect Gentx
 
-After you create your gentx, you will need to submit it to the network. You can do this by creating a PR to the network repository with your gentx file, or by collecting all gentx files in the `~/.manifest/config/gentx` then running `manifestd genesis collect-gentxs` to collect all gentx files and create a new genesis file.
+After you create your gentx, you will need to submit it to the network. You can do this by creating a PR to the network repository with your gentx file, or by collecting all gentx files in `${HOME}/.manifest/config/gentx` then running `manifestd genesis collect-gentxs` to collect all gentx files and create a new genesis file.
 
 ## Start your node
 

--- a/network/manifest-1/GENESIS.md
+++ b/network/manifest-1/GENESIS.md
@@ -87,10 +87,10 @@ CHAIN_ID='manifest-1'
 PROJECT_HOME="${HOME}/.manifest"
 KEYNAME_ADDR=$(manifestd keys show $KEYNAME -a)
 
-# Reset prior state and any leftover gentxs / stale genesis. `comet
-# unsafe-reset-all` only clears the data directory; genesis.json lives
-# under config/ and survives, so on reruns we need to remove it
-# explicitly before `init` (otherwise init fails with
+# Reset prior state and any leftover gentxs / stale genesis. Note that
+# 'comet unsafe-reset-all' only clears the data directory; genesis.json
+# lives under config/ and survives, so on reruns we need to remove it
+# explicitly before 'init' (otherwise init fails with
 # "genesis.json file already exists").
 manifestd comet unsafe-reset-all
 rm -f $HOME/.manifest/config/genesis.json

--- a/network/manifest-1/GENESIS.md
+++ b/network/manifest-1/GENESIS.md
@@ -87,20 +87,25 @@ CHAIN_ID='manifest-1'
 PROJECT_HOME="${HOME}/.manifest"
 KEYNAME_ADDR=$(manifestd keys show $KEYNAME -a)
 
-# Remove old files if they exist and replace genesis.json
+# Reset prior state and any leftover gentxs.
 manifestd comet unsafe-reset-all
-rm $HOME/.manifest/config/genesis.json
-rm $HOME/.manifest/config/gentx/*.json
+rm -f $HOME/.manifest/config/gentx/*.json
+
+# Initialise a fresh config + genesis. --default-denom (umfx) controls the
+# local fee/gas denom. Cosmos SDK v0.50's `init` does NOT accept a
+# --staking-bond-denom flag; the staking bond denom is set on the genesis
+# JSON itself, by the canonical mainnet `manifest-1_genesis.json` we
+# replace below or — for a custom chain — by `set-genesis-params.sh`'s
+# jq override on `.app_state.staking.params.bond_denom`.
+manifestd init "$MONIKER" --chain-id $CHAIN_ID --default-denom umfx
+
+# Replace the freshly-init'd genesis with the canonical mainnet template
+# BEFORE adding your account / running gentx — otherwise add-genesis-account
+# and gentx would target a genesis with the wrong network parameters.
+rm -f $HOME/.manifest/config/genesis.json
 wget https://raw.githubusercontent.com/manifest-network/manifest-ledger/main/network/manifest-1/manifest-1_genesis.json -O $HOME/.manifest/config/genesis.json
 
-# Give yourself 1POASTAKE for the genesis Tx signed.
-# --default-denom (umfx) controls the local fee/gas denom. Cosmos SDK v0.50's
-# `init` does NOT accept a --staking-bond-denom flag; the staking bond denom
-# is set on the genesis JSON itself, either by the canonical mainnet
-# `manifest-1_genesis.json` you wgot above, or — for a custom chain — by the
-# `set-genesis-params.sh` script's jq override on
-# `.app_state.staking.params.bond_denom`.
-manifestd init "$MONIKER" --chain-id $CHAIN_ID --default-denom umfx
+# Give yourself 1 POASTAKE so you can sign the genesis tx.
 manifestd genesis add-genesis-account $KEYNAME_ADDR 1000000upoa
 
 # genesis transaction using all above variables

--- a/network/manifest-1/GENESIS.md
+++ b/network/manifest-1/GENESIS.md
@@ -94,9 +94,13 @@ rm $HOME/.manifest/config/gentx/*.json
 wget https://raw.githubusercontent.com/manifest-network/manifest-ledger/main/network/manifest-1/manifest-1_genesis.json -O $HOME/.manifest/config/genesis.json
 
 # Give yourself 1POASTAKE for the genesis Tx signed.
-# --default-denom (umfx) controls the local fee/gas denom; --staking-bond-denom (upoa)
-# is the staking denom that must match the genesis app_state.staking.params.bond_denom.
-manifestd init "$MONIKER" --chain-id $CHAIN_ID --default-denom umfx --staking-bond-denom upoa
+# --default-denom (umfx) controls the local fee/gas denom. Cosmos SDK v0.50's
+# `init` does NOT accept a --staking-bond-denom flag; the staking bond denom
+# is set on the genesis JSON itself, either by the canonical mainnet
+# `manifest-1_genesis.json` you wgot above, or — for a custom chain — by the
+# `set-genesis-params.sh` script's jq override on
+# `.app_state.staking.params.bond_denom`.
+manifestd init "$MONIKER" --chain-id $CHAIN_ID --default-denom umfx
 manifestd genesis add-genesis-account $KEYNAME_ADDR 1000000upoa
 
 # genesis transaction using all above variables

--- a/network/manifest-1/GENESIS.md
+++ b/network/manifest-1/GENESIS.md
@@ -87,8 +87,13 @@ CHAIN_ID='manifest-1'
 PROJECT_HOME="${HOME}/.manifest"
 KEYNAME_ADDR=$(manifestd keys show $KEYNAME -a)
 
-# Reset prior state and any leftover gentxs.
+# Reset prior state and any leftover gentxs / stale genesis. `comet
+# unsafe-reset-all` only clears the data directory; genesis.json lives
+# under config/ and survives, so on reruns we need to remove it
+# explicitly before `init` (otherwise init fails with
+# "genesis.json file already exists").
 manifestd comet unsafe-reset-all
+rm -f $HOME/.manifest/config/genesis.json
 rm -f $HOME/.manifest/config/gentx/*.json
 
 # Initialise a fresh config + genesis. --default-denom (umfx) controls the

--- a/network/manifest-1/POST_GENESIS.md
+++ b/network/manifest-1/POST_GENESIS.md
@@ -1,14 +1,14 @@
-# Post-Genesis
+# Post-Genesis: Joining manifest-1
 
-## Become a validator
+This guide walks a validator (or full node) through joining the live `manifest-1` chain after launch. For the genesis-ceremony flow, see [GENESIS.md](./GENESIS.md). For the upgrade runbook, see [UPGRADES.md](./UPGRADES.md).
 
-### Hardware Requirements
+## Hardware Requirements
 
 **Minimal**
 
 - 4 GB RAM
 - 100 GB SSD
-- 3.2 x4 GHz CPU
+- 3.2 GHz x4 CPU
 
 **Recommended**
 
@@ -18,7 +18,7 @@
 
 **Operating System**
 
-- Linux (x86_64) or Linux (amd64) Recommended Arch Linux
+- Linux (x86_64 with SSSE3) or Linux (arm64 with NEON). CosmWasm requires SSSE3 / NEON — older CPUs will not run the binary.
 
 ### Dependencies
 
@@ -27,7 +27,7 @@
 **Arch Linux:**
 
 ```
-pacman -S go git gcc make
+pacman -S go git gcc make jq
 ```
 
 **Ubuntu Linux:**
@@ -37,56 +37,131 @@ sudo snap install go --classic
 sudo apt-get install git gcc make jq
 ```
 
-### Install the manifest binary
+## Install the manifestd binary
+
+Pin to the version currently running on `manifest-1`. Mainnet's current version is published in the [GitHub releases](https://github.com/manifest-network/manifest-ledger/releases) — pick the latest non-pre-release tag.
 
 ```bash
-# Clone git repository
 git clone https://github.com/manifest-network/manifest-ledger.git
 cd manifest-ledger
-git checkout VERSION
+git checkout v2.1.0   # replace with the current mainnet tag
 
-make install # go install ./...
-# For ledger support `go install -tags ledger ./...`
+make install                       # go install ./...
+# For ledger support:
+# go install -tags ledger ./...
+
 manifestd config set client chain-id manifest-1
 ```
 
-OR
+OR download a published binary:
 
 ```bash
-wget <link to manifest precompile>
+# Pull the matching binary from GitHub releases:
+# https://github.com/manifest-network/manifest-ledger/releases/<tag>
 chmod +x manifestd
-mv manifestd /usr/local/bin
+sudo mv manifestd /usr/local/bin
 ```
 
-### Generate keys
+## Generate keys
 
-- `manifestd keys add [key_name]`
-- `manifestd keys add [key_name] --recover` to regenerate keys with your BIP39 mnemonic to add ledger key
-- `manifestd keys add [key_name] --ledger` to add a ledger key
+- `manifestd keys add [key_name]` — new key
+- `manifestd keys add [key_name] --recover` — restore from BIP39 mnemonic
+- `manifestd keys add [key_name] --ledger` — add a Ledger-backed key
 
-### Configure & start your node
-
-- #### Intialize
-  `manifestd init <moniker> --chain-id manifest-1 --default-denom upoa`
-- #### Genesis
-  `cp github.com/manifest-network/manifest-ledger/network/manifest-1/manifest-1_genesis.json ~/.manifestd/config/genesis.json`
-- #### Peers
-  `sed -i 's/seeds = ""/seeds = "SEED_ADDRESS"/g' ${HOME}/.manifest/config/config.toml`
-- #### Minimum Gas
-  `sed -i 's/minimum-gas-prices = "0stake"/minimum-gas-prices = "0umfx"/g' ${HOME}/.manifest/config/app.toml`
-- #### Start
-  **Create a systemd service file**
+## Initialise & configure your node
 
 ```bash
-cat <<EOF | sudo tee /etc/systemd/system/manifestd.service
+# --default-denom is the local fee/gas denom (umfx). The staking bond_denom (upoa)
+# is set in mainnet's genesis.json — do NOT pass --staking-bond-denom here, otherwise
+# `genesis validate` will mismatch the downloaded mainnet genesis.
+manifestd init <moniker> --chain-id manifest-1 --default-denom umfx
+```
+
+### Genesis
+
+Replace the freshly-generated `genesis.json` with the canonical mainnet file:
+
+```bash
+wget https://raw.githubusercontent.com/manifest-network/manifest-ledger/main/network/manifest-1/manifest-1_genesis.json \
+  -O ~/.manifest/config/genesis.json
+
+manifestd genesis validate ~/.manifest/config/genesis.json
+```
+
+### Minimum gas prices
+
+`manifest-1`'s gas/fee denom is `umfx`. Update `app.toml`:
+
+```bash
+sed -i 's/minimum-gas-prices = "0stake"/minimum-gas-prices = "0umfx"/g' \
+  ~/.manifest/config/app.toml
+```
+
+### Peers
+
+Add seeds and/or persistent peers in `~/.manifest/config/config.toml`. Authoritative sources for current peer values:
+
+- The [`cosmos/chain-registry` entry for `manifest`](https://github.com/cosmos/chain-registry/tree/master/manifest) (`peers.seeds`, `peers.persistent_peers`).
+- The Manifest Network Discord `#validators` channel.
+- The latest [GitHub release notes](https://github.com/manifest-network/manifest-ledger/releases) when peers change at an upgrade boundary.
+
+```bash
+# Example shape — replace SEED1@... with values pulled from one of the sources above:
+sed -i 's|seeds = ""|seeds = "SEED1@host1:26656,SEED2@host2:26656"|' \
+  ~/.manifest/config/config.toml
+```
+
+### State-sync (optional, fastest path)
+
+State-sync lets a fresh node skip block-by-block replay and snapshot directly to a recent height. The mainnet `app.toml` defaults disable this. Enable it like so (replace `RPC_SERVERS`, `TRUST_HEIGHT`, `TRUST_HASH` with values pulled from chain-registry / Discord / a trusted RPC operator):
+
+```bash
+SNAP_RPC1="https://rpc.example.org:443"
+SNAP_RPC2="https://rpc.example.com:443"
+
+# Trust height should be a recent block (typically `latest height - ~1000`).
+# Trust hash is the block hash at that height — query from a trusted RPC:
+#   curl -s "$SNAP_RPC1/block?height=<trust_height>" | jq -r '.result.block_id.hash'
+
+cat <<EOF >> ~/.manifest/config/config.toml
+# State-sync overrides
+EOF
+
+# Edit ~/.manifest/config/config.toml under [statesync]:
+# enable = true
+# rpc_servers = "$SNAP_RPC1,$SNAP_RPC2"
+# trust_height = <TRUST_HEIGHT>
+# trust_hash = "<TRUST_HASH>"
+# trust_period = "168h0m0s"
+```
+
+> **Heads-up:** wasm contract state cannot be state-synced today (CosmWasm limitation as of wasmd 0.54). If contracts are critical for your node's role, prefer a snapshot or full replay.
+
+### Snapshots (alternative to state-sync)
+
+Snapshot tarballs let you bypass replay without state-sync's wasm caveat. Authoritative snapshot URLs are published by the Manifest Network team and partners — see the chain-registry entry, Discord `#validators`, or release notes for current locations. The shape is:
+
+```bash
+# Example shape — replace URL with a published mainnet snapshot:
+wget -O - https://snapshots.example.org/manifest-1/manifest-1_latest.tar.lz4 \
+  | lz4 -d \
+  | tar -xv -C ~/.manifest
+```
+
+Always verify the publisher's checksum before extracting.
+
+## Run as a systemd service
+
+```bash
+sudo tee /etc/systemd/system/manifestd.service > /dev/null <<EOF
 [Unit]
 Description=Manifest Node
 After=network.target
 
 [Service]
 Type=simple
-User=root
-WorkingDirectory=${HOME}
+User=$(whoami)
+WorkingDirectory=$HOME
 Environment="POA_ADMIN_ADDRESS=manifest1wxjfftrc0emj5f7ldcvtpj05lxtz3t2npghwsf"
 ExecStart=/usr/local/bin/manifestd start
 Restart=on-failure
@@ -98,46 +173,51 @@ LimitMEMLOCK=209715200
 [Install]
 WantedBy=multi-user.target
 EOF
-```
 
-**Start your service**
-
-```bash
-sudo systemctl enable manifestd
 sudo systemctl daemon-reload
-sudo sytemctl start manifestd && journalctl -u manifestd -f -o cat --no-hostname
+sudo systemctl enable manifestd
+sudo systemctl start manifestd
+journalctl -u manifestd -f -o cat --no-hostname
 ```
 
-### Join the network
+> **Recommended:** run `manifestd` under [`cosmovisor`](https://docs.cosmos.network/main/build/tooling/cosmovisor) so chain upgrades happen automatically. See [UPGRADES.md](./UPGRADES.md) for the cosmovisor layout used on `manifest-1`.
 
-- #### Generate your validator file
+## Become a validator
 
-Use this command to generate your validator file and change all the entries to your own information. `amount` should remain the same unless the team specifies otherwise. 1 POA power is 1000000upoa.
+`manifest-1` runs **Proof of Authority** (`x/poa`). Submitting a `create-validator` puts you in the pending queue; the PoA admin (or admin group) must approve before you join the active set. Self-bonding is not required for PoA.
+
+### Generate your validator file
+
+`amount` should remain `1000000upoa` (= 1 POA power) unless the team specifies otherwise.
 
 ```bash
 cat <<EOF > validator.json
 {
-  "pubkey": {"@type":"/cosmos.crypto.ed25519.PubKey","key":"oWg2ISpLF405Jcm2vXV+2v4fnjodh6aafuIdeoW+rUw="},
+  "pubkey": $(manifestd comet show-validator),
   "amount": "1000000upoa",
-  "moniker": "validator's name",
-  "identity": "keybase-identity",
-  "website": "validator's (optional) website",
-  "security": "validator's (optional) security contact email",
-  "details": "validator's (optional) details",
+  "moniker": "<your validator name>",
+  "identity": "<keybase identity>",
+  "website": "<https://your.site>",
+  "security": "<security contact email>",
+  "details": "<short description>",
   "commission-rate": "0.1",
   "commission-max-rate": "0.2",
   "commission-max-change-rate": "0.01",
   "min-self-delegation": "1"
 }
 EOF
-
 ```
 
-You can find your pubkey information by running `manifestd tendermint show-validator`
+### Submit creation transaction
 
-- #### Submit creation transaction
-  `manifestd tx poa create-validator path/to/validator.json --from keyname`
+```bash
+manifestd tx poa create-validator path/to/validator.json --from <keyname>
+```
 
-**Following these instructions, your validator will be put into a queue for the chain admins to accept or reject.**. You can view this queue by running `manifestd q poa pending-validators`.
+Your request enters a pending queue:
 
-If accepted, you will become a validator on the network with the PoA admin's desired power for you.
+```bash
+manifestd query poa pending-validators
+```
+
+If the PoA admin accepts, you'll appear in the active validator set with the power they assigned. If rejected (`manifestd tx poa remove-pending`), resubmit after addressing whatever they flagged.

--- a/network/manifest-1/POST_GENESIS.md
+++ b/network/manifest-1/POST_GENESIS.md
@@ -71,9 +71,11 @@ sudo mv manifestd /usr/local/bin
 ## Initialise & configure your node
 
 ```bash
-# --default-denom is the local fee/gas denom (umfx). The staking bond_denom (upoa)
-# is set in mainnet's genesis.json — do NOT pass --staking-bond-denom here, otherwise
-# `genesis validate` will mismatch the downloaded mainnet genesis.
+# --default-denom is the local fee/gas denom (umfx). The staking bond_denom
+# (upoa) comes baked into mainnet's genesis.json — Cosmos SDK v0.50's `init`
+# command doesn't expose a separate flag for it, so just `--default-denom`
+# is what you pass here. The freshly-init'd genesis.json gets replaced by
+# the canonical mainnet file in the next step anyway.
 manifestd init <moniker> --chain-id manifest-1 --default-denom umfx
 ```
 

--- a/network/manifest-1/README.md
+++ b/network/manifest-1/README.md
@@ -1,29 +1,38 @@
 # Manifest-1 Network Guide
 
-This guide will assist you in setting up a Manifest-1 network. There are three primary methods to join the network:
+This directory holds the operator-facing docs and the canonical mainnet genesis file for `manifest-1`. Pick the path that matches what you're trying to do:
 
-1. [Genesis](./GENESIS.md): For validators joining at the network's inception, please refer to the genesis document.
-2. [Post Genesis](./POST_GENESIS.md): For validators joining after the initial network launch, consult the post-genesis document.
-3. [Custom Genesis](#custom-genesis): To create your genesis file, follow the custom genesis guide.
+| If you want to… | Read |
+|---|---|
+| Join the **live** `manifest-1` chain as a validator or full node | [POST_GENESIS.md](./POST_GENESIS.md) |
+| Track or pre-stage an **upgrade** | [UPGRADES.md](./UPGRADES.md) |
+| Bootstrap a **new chain** from scratch (testnet, devnet, fork) | [GENESIS.md](./GENESIS.md) + [Custom Genesis](#custom-genesis) below |
 
-## [Genesis](./GENESIS.md)
+The frozen mainnet genesis is checked in as [`manifest-1_genesis.json`](./manifest-1_genesis.json). The other JSON file (`genesis.json`) is a `manifestd` `init` artefact, **not** a usable network genesis — ignore it.
 
-This section is tailored for validators intending to participate in the genesis ceremony. Prospective validators must download the genesis file and adhere to the provided steps to join the network. The genesis file originates from the [set-genesis-params.sh](./set-genesis-params.sh) script, which facilitates the generation of a bespoke genesis file. This file allows for the specification of network parameters, such as the Proof of Authority (PoA) token denomination.
+## Authoritative sources for live values
 
-## [Post Genesis](./POST_GENESIS.md)
+Some operator inputs change between releases and live outside this repo:
 
-This section addresses validators aiming to join the network post-initial launch. Such validators need to execute the outlined steps to generate their validator file and integrate into the network by submitting a join request to the PoA administrators.
+- **Seeds, persistent peers, RPC endpoints** — [`cosmos/chain-registry`](https://github.com/cosmos/chain-registry/tree/master/manifest), Manifest Network Discord `#validators`.
+- **Snapshots, state-sync RPC servers** — Discord `#validators`, release notes.
+- **Current binary version** — [GitHub releases](https://github.com/manifest-network/manifest-ledger/releases) (latest non-pre-release tag).
+- **Scheduled upgrade height** — `manifestd query upgrade plan` against any live RPC.
 
 ## Custom Genesis
 
-This section is for those who wish to construct their genesis file for the network, enabling the modification of PoA administrator details and other parameters. Utilizing the [set-genesis-params.sh](./set-genesis-params.sh) script, you can alter the PoA denomination, among other settings.
+For anyone bootstrapping a new chain from this repo (testnet, devnet, fork): use [`set-genesis-params.sh`](./set-genesis-params.sh) to generate a fresh genesis with custom PoA admin(s), denomination, and other parameters.
 
-In the script, you will encounter the following line:
+Key knobs in the script:
 
 ```bash
+# Staking denom (PoA bond denom). Distinct from the gas/fee denom.
 update_genesis '.app_state["staking"]["params"]["bond_denom"]="upoa"'
+
+# CosmWasm code-upload allowlist — set this to your chain's PoA admin(s):
+update_genesis '.app_state["wasm"]["params"]["code_upload_access"]["addresses"]=["<your-admin-addr>"]'
 ```
 
-Modifying the quoted values allows you to customize them as desired. After making the changes, execute the script, and your revised genesis file will be located at `$HOME/.manifest/config/genesis.json`.
+Run the script, then pick up at [GENESIS.md](./GENESIS.md) to complete the genesis-ceremony flow.
 
-Following these adjustments, proceed to the [Genesis](./GENESIS.md) document to finalize your node setup and participate in the genesis ceremony or launch your own.
+> The script's `add-genesis-account` block is commented out — you'll need to uncomment and fill it in for any chain that should ship with seeded balances.

--- a/network/manifest-1/UPGRADES.md
+++ b/network/manifest-1/UPGRADES.md
@@ -77,17 +77,24 @@ When the chain hits the upgrade height, cosmovisor stops the current process, sw
 
 ## Released versions
 
-Mainnet runs the latest non-pre-release tag from this repo. Each row below summarises the upgrade-impact pieces only — see the linked release notes for the full changelog.
+Mainnet's `genesis_time` is **2024-04-10**, predating the formal `v1.x.x` tag series — the chain ran on `v0.0.1-rc.*` builds through early 2025. Each row below summarises the upgrade-impact pieces only; the full release notes (the `Description` field of each tag) live at <https://github.com/manifest-network/manifest-ledger/releases>. Mainnet runs the latest non-pre-release tag.
 
 | Version | Released | Major changes | Operator action |
 |---------|----------|---------------|-----------------|
-| `v1.0.0` | 2025-02-21 | First stable mainnet release. Cosmos SDK 0.50.12. | Initial install. |
-| `v1.0.1` – `v1.0.14` | 2025-03 → 2026-01 | Patch releases: dependency bumps, pin fixes (e.g. `cosmossdk.io/x/tx`), CometBFT bumps. No state migrations. | Pre-stage tag, vote on upgrade proposal, swap binary. |
-| `v2.0.0` | 2026-02-27 | **Breaking — billing v2.** Adds `x/sku` and `x/billing` modules; introduces `x/wasm`-permissioned providers; price/lease/credit semantics. New keepers wired into the upgrade handler (see `app.AppKeepers`). Reads PoA admin from `manifest1afk9zr2hn2jsac63h4hm60vl9z3e5u69gndzf7c99cqge3vzwjzsfmy9qj` per the seeded params. | **Required upgrade.** Pre-stage `v2.0.0`. Backup state before running. |
-| `v2.0.1` | 2026-03-24 | Go 1.25.8 bump. No state changes. | Standard binary swap. |
-| `v2.0.2` | 2026-04-08 | wasmd 0.54.2 → 0.54.3. No state changes. | Standard binary swap. |
-| `v2.0.3` | 2026-04-16 | Determinism-under-load fixes; genesis-validation fixes (#150). No state migration but fixes a class of consensus-divergence under load — **prioritise this upgrade**. | Standard binary swap; recommended ASAP after release. |
+| `v1.0.0` | 2025-02-21 | First formal `v1.x.x` tag. Security fix for ASA-2025-003. Cosmos SDK 0.50.12. **No change to chain handler logic** — the chain-code update is a libwasmvm requirement bump. Requires `libwasmvm` [v2.2.2](https://github.com/CosmWasm/wasmvm/releases/v2.2.2). | Coordinated upgrade from the prior RC binary. Update `libwasmvm` on the host alongside the binary swap. |
+| `v1.0.1` | 2025-03-03 | Security fix for ASA-2025-004. Requires `libwasmvm` v2.2.2. | Coordinated upgrade; bump `libwasmvm`. |
+| `v1.0.2` – `v1.0.3` | 2025-03 | Patch fixes / pin updates around `cosmossdk.io/x/tx`. | Standard binary swap. |
+| `v1.0.4` | 2025-04-02 | **Behavioural change — IBC Transfers disabled** at this release. (No store migration; transfer messages are rejected at the application layer.) | Coordinated upgrade. After the swap, IBC `MsgTransfer` will fail until a future release re-enables it. |
+| `v1.0.5` – `v1.0.6` | 2025-06 → 2025-08 | Dependency bumps. | Standard binary swap. |
+| `v1.0.7` | 2025-08-18 | GitHub-org rename (`liftedinit` → `manifest-network`), Go and dependency bumps. Requires `libwasmvm` v2.2.4. | Coordinated upgrade; **bump `libwasmvm` to v2.2.4** (older v2.2.2 will fail to load). |
+| `v1.0.8` – `v1.0.14` | 2025-08 → 2026-01 | Periodic dependency bumps (CometBFT, ibc-go, wasmd). Each release continues to require `libwasmvm` v2.2.4. No state migrations. | Coordinated binary swap per release. |
+| `v2.0.0` | 2026-02-27 | **Breaking — billing v2** (#144). Adds `x/sku` and `x/billing` modules with new keepers wired into the upgrade handler (`app.AppKeepers`); bumps Cosmos SDK 0.50.12 → 0.50.14, wasmd 0.54.0 → 0.54.2, CometBFT 0.38.17 → 0.38.21, ibc-go 8.4.0 → 8.7.0; switches the `cosmos-sdk` replace directive from `liftedinit/cosmos-sdk` to `manifest-network/cosmos-sdk`. | **Required upgrade.** Pre-stage `v2.0.0`. Backup state before running. Plan downtime — the new module stores need to initialise. |
+| `v2.0.1` | 2026-03-25 | Go 1.25.7 → 1.25.8 bump (#147). No state changes. | Standard binary swap. |
+| `v2.0.2` | 2026-04-08 | wasmd 0.54.2 → 0.54.3 (#148). No state changes. | Standard binary swap. |
+| `v2.0.3` | 2026-04-16 | Determinism-under-load fix and genesis-validation hardening (#150). No state migration but addresses a class of consensus divergence — **prioritise this upgrade**. | Standard binary swap; recommended ASAP after release. |
 | `v2.1.0` | 2026-04-30 | **Feature — per-item custom domains** (#152). Adds `MsgSetItemCustomDomain`, `LeaseItem.custom_domain`, `Params.reserved_domain_suffixes`, `Query/LeaseByCustomDomain`, and the `CustomDomainIndex` reverse-lookup. New error codes 29–33. Backward-compatible: existing leases keep `custom_domain == ""`. | Standard binary swap. After upgrade, authority should consider seeding `Params.reserved_domain_suffixes` for any provider wildcard zones via `update-params --reserved-domain-suffixes "..."`. |
+
+> **Upgrade-name discipline.** Every release's GitHub note records `Upgrade Handler Name: <tag>` exactly — `v1.0.0`, `v2.0.0`, `v2.1.0`, etc. When voting on an upgrade proposal, confirm `plan.name` (or `manifestd query upgrade plan`) matches the published `Upgrade Handler Name` byte-for-byte before staging the binary at `$DAEMON_HOME/cosmovisor/upgrades/<name>/bin/`.
 
 ### Where to learn about upcoming upgrades
 

--- a/network/manifest-1/UPGRADES.md
+++ b/network/manifest-1/UPGRADES.md
@@ -1,0 +1,132 @@
+# manifest-1 Upgrade Runbook
+
+This document covers how chain upgrades work on `manifest-1` and the running list of released versions. For first-time install, see [POST_GENESIS.md](./POST_GENESIS.md).
+
+## How upgrades work on manifest-1
+
+Upgrades are coordinated through the Cosmos SDK `x/upgrade` module. The flow:
+
+1. The PoA authority (or PoA admin group) submits a `MsgSoftwareUpgrade` proposal naming the target version (e.g. `v2.1.0`) and a target block height.
+2. At the target height, every validator's `manifestd` panics with `UPGRADE NEEDED`.
+3. Each operator stops the old binary, swaps in the new one (cosmovisor automates this), and starts again.
+4. The new binary detects the registered upgrade name, runs the matching upgrade handler (typically `RunMigrations`), and resumes block production.
+
+### The "next" handler pattern
+
+This repo uses a single generic upgrade handler — [`app/upgrades/next/upgrades.go`](../../app/upgrades/next/upgrades.go) — re-named per release at app boot:
+
+```go
+// app/upgrades.go
+Upgrades = append(Upgrades, next.NewUpgrade(app.Version()))
+```
+
+The handler is a no-op that runs module migrations. Implication for operators: **the upgrade name on `manifest-1` is always the binary's version string** (the `git describe` output baked in at build time, e.g. `v2.1.0`). When voting on an upgrade proposal, confirm `plan.name` equals the tag of the release you intend to run.
+
+> If a future release needs a non-trivial migration (state surgery, store renames, etc.), the team will replace the noop body in `app/upgrades/next/upgrades.go` for that release. Read the release notes carefully — a non-noop release may set `StoreUpgrades` and require operators to recompute disk-resident state.
+
+## cosmovisor (recommended)
+
+Run `manifestd` under [cosmovisor](https://docs.cosmos.network/main/build/tooling/cosmovisor) so the binary swap at upgrade height is automatic.
+
+### Layout
+
+```
+$DAEMON_HOME/                       # ~/.manifest by default
+├── cosmovisor/
+│   ├── current  -> genesis | upgrades/<name>
+│   ├── genesis/
+│   │   └── bin/
+│   │       └── manifestd           # the launch-version binary
+│   └── upgrades/
+│       └── <upgrade_name>/         # e.g. v2.1.0
+│           └── bin/
+│               └── manifestd       # the post-upgrade binary
+```
+
+### Environment
+
+```bash
+# /etc/systemd/system/manifestd.service (or your shell rc)
+Environment="DAEMON_NAME=manifestd"
+Environment="DAEMON_HOME=/home/<user>/.manifest"
+Environment="DAEMON_RESTART_AFTER_UPGRADE=true"
+Environment="DAEMON_ALLOW_DOWNLOAD_BINARIES=false"   # security — pre-stage manually
+Environment="UNSAFE_SKIP_BACKUP=false"               # keep snapshot backups
+```
+
+### Pre-staging the next binary
+
+For each upcoming `<upgrade_name>` (= the next release tag):
+
+```bash
+# Build the target version locally
+cd manifest-ledger
+git fetch --tags
+git checkout <upgrade_name>          # e.g. v2.2.0
+make build
+
+# Place it where cosmovisor expects it
+mkdir -p $DAEMON_HOME/cosmovisor/upgrades/<upgrade_name>/bin
+cp ./build/manifestd $DAEMON_HOME/cosmovisor/upgrades/<upgrade_name>/bin/
+
+# Verify
+$DAEMON_HOME/cosmovisor/upgrades/<upgrade_name>/bin/manifestd version
+```
+
+When the chain hits the upgrade height, cosmovisor stops the current process, switches `cosmovisor/current` to the new directory, and restarts.
+
+## Released versions
+
+Mainnet runs the latest non-pre-release tag from this repo. Each row below summarises the upgrade-impact pieces only — see the linked release notes for the full changelog.
+
+| Version | Released | Major changes | Operator action |
+|---------|----------|---------------|-----------------|
+| `v1.0.0` | 2025-02-21 | First stable mainnet release. Cosmos SDK 0.50.12. | Initial install. |
+| `v1.0.1` – `v1.0.14` | 2025-03 → 2026-01 | Patch releases: dependency bumps, pin fixes (e.g. `cosmossdk.io/x/tx`), CometBFT bumps. No state migrations. | Pre-stage tag, vote on upgrade proposal, swap binary. |
+| `v2.0.0` | 2026-02-27 | **Breaking — billing v2.** Adds `x/sku` and `x/billing` modules; introduces `x/wasm`-permissioned providers; price/lease/credit semantics. New keepers wired into the upgrade handler (see `app.AppKeepers`). Reads PoA admin from `manifest1afk9zr2hn2jsac63h4hm60vl9z3e5u69gndzf7c99cqge3vzwjzsfmy9qj` per the seeded params. | **Required upgrade.** Pre-stage `v2.0.0`. Backup state before running. |
+| `v2.0.1` | 2026-03-24 | Go 1.25.8 bump. No state changes. | Standard binary swap. |
+| `v2.0.2` | 2026-04-08 | wasmd 0.54.2 → 0.54.3. No state changes. | Standard binary swap. |
+| `v2.0.3` | 2026-04-16 | Determinism-under-load fixes; genesis-validation fixes (#150). No state migration but fixes a class of consensus-divergence under load — **prioritise this upgrade**. | Standard binary swap; recommended ASAP after release. |
+| `v2.1.0` | 2026-04-30 | **Feature — per-item custom domains** (#152). Adds `MsgSetItemCustomDomain`, `LeaseItem.custom_domain`, `Params.reserved_domain_suffixes`, `Query/LeaseByCustomDomain`, and the `CustomDomainIndex` reverse-lookup. New error codes 29–33. Backward-compatible: existing leases keep `custom_domain == ""`. | Standard binary swap. After upgrade, authority should consider seeding `Params.reserved_domain_suffixes` for any provider wildcard zones via `update-params --reserved-domain-suffixes "..."`. |
+
+### Where to learn about upcoming upgrades
+
+- [GitHub releases](https://github.com/manifest-network/manifest-ledger/releases) — release notes, breaking-change call-outs, build artifacts.
+- The Manifest Network Discord `#validators` channel — proposal heights, scheduled coordination calls, snapshot updates.
+- `manifestd query upgrade plan` — the currently scheduled upgrade (if any) on the live chain.
+
+## Standard upgrade procedure (TL;DR)
+
+```bash
+# 1. Read the release notes for breaking changes / migration impact:
+#    https://github.com/manifest-network/manifest-ledger/releases/tag/<NEW_TAG>
+
+# 2. Build & pre-stage the new binary under cosmovisor:
+git fetch --tags
+git checkout <NEW_TAG>
+make build
+mkdir -p $DAEMON_HOME/cosmovisor/upgrades/<NEW_TAG>/bin
+cp ./build/manifestd $DAEMON_HOME/cosmovisor/upgrades/<NEW_TAG>/bin/
+
+# 3. Confirm the proposal name on-chain matches <NEW_TAG>:
+manifestd query gov proposal <PROPOSAL_ID>
+manifestd query upgrade plan      # after the proposal passes
+
+# 4. (Optional) take a backup before the upgrade height:
+tar czf manifest-pre-<NEW_TAG>.tar.gz -C $HOME .manifest/data
+
+# 5. Wait. cosmovisor handles the swap at the upgrade height.
+
+# 6. Verify:
+manifestd version                  # should print <NEW_TAG>
+manifestd status | jq '.sync_info.latest_block_height'   # should be advancing
+```
+
+## Rolling back
+
+Rolling back a finalised upgrade is **not** safe — the chain has already produced blocks under the new binary. If you need to roll back:
+
+- For an aborted upgrade (binary crashes before the chain advances past the upgrade height): point `cosmovisor/current` back at `genesis/` (or the previous upgrade dir), restart, and coordinate a re-proposal.
+- For a post-finalisation rollback (catastrophic bug): you are in chain-halt territory. Coordinate on Discord — this needs a multi-validator restore from a pre-upgrade snapshot under a new upgrade proposal.
+
+Always test upgrades on a local chain (`make local-image` + `make ictest-chain-upgrade`) or testnet first.

--- a/x/billing/README.md
+++ b/x/billing/README.md
@@ -89,6 +89,54 @@ Leases follow a two-phase commit pattern:
 4. **REJECTED**: Provider rejected the pending lease, or tenant cancelled it
 5. **EXPIRED**: Pending lease timed out (exceeded `pending_timeout` parameter)
 
+### Custom Domains (per-item)
+
+Each `LeaseItem` can carry an optional `custom_domain` — an FQDN that the
+provider routes to that item's container with a TLS cert provisioned via
+HTTP-01. Domains are set or cleared after lease creation via
+`MsgSetItemCustomDomain` and addressed by `service_name` (use `""` for a
+1-item legacy lease).
+
+**Authorisation.** The lease tenant, the module authority, and any address in
+`params.allowed_list` may set or clear a domain. The lease must be in
+`PENDING` or `ACTIVE` state; closed/rejected/expired leases are immutable.
+
+**Validation rules** (`IsValidFQDN`):
+- 1 to **253** bytes (`MaxCustomDomainLength`); lowercase only.
+- ≥ 1 dot separator (at least 2 labels).
+- Each label is RFC 1123 (1-63 alphanumerics + hyphens, no leading/trailing
+  hyphen).
+- The TLD label must contain at least one non-digit (rejects raw IPs).
+- No scheme (`://`), no `/ \t \s @ * ? #`, no leading or trailing dot.
+
+**Reserved suffixes** (`params.reserved_domain_suffixes`). Tenants cannot
+claim a domain that matches any reserved suffix. Each suffix entry must begin
+with `.` (e.g. `.barney0.manifest0.net`); a domain matches when it ends with
+the suffix at a label boundary, or equals the suffix's apex
+(`barney0.manifest0.net`). The check is case-insensitive and fail-closed on
+malformed entries. Reserved suffixes are tunable via governance — providers
+that bring up new wildcard zones can be added without a chain upgrade.
+
+**Uniqueness.** A domain may be claimed by at most one PENDING/ACTIVE lease
+item at a time. The keeper maintains a `CustomDomainIndex` reverse-lookup
+(prefix `0x0C`, value `CustomDomainTarget{lease_uuid, service_name}`) so
+`QueryLeaseByCustomDomain` returns the routing target in O(1) without
+iterating items. Closing, rejecting, expiring, or auto-closing a lease frees
+the index entry. Re-setting the same domain on the same item is idempotent
+(no event, no state change).
+
+**Multi-item legacy leases cannot use custom_domain.** When a multi-item
+lease was created without `service_name`s (legacy mode), the addressing key
+is empty for all items and the lookup is ambiguous. Recreate the lease in
+service-name mode instead.
+
+**Events**:
+- `lease_custom_domain_set` — attributes: `lease_uuid`, `tenant`, `service_name`, `custom_domain`, `set_by`
+- `lease_custom_domain_cleared` — same attributes (`custom_domain` carries the previous value)
+
+`set_by` ∈ {`tenant`, `authority`, `allowed`} indicates the role under which
+the call was authorised.
+
 ### Price Locking
 
 When a lease is created, the current prices of all SKUs are locked in for the duration of the lease. Price changes to SKUs only affect newly created leases.
@@ -150,6 +198,7 @@ If a tenant's credit balance is insufficient to cover accrued charges, the billi
 | `0x09` | LeaseByTenantState | Compound index: tenant+state → lease UUIDs |
 | `0x0A` | LeaseBySKU | Many-to-many index: SKU UUID → lease UUIDs |
 | `0x0B` | LeaseByStateCreatedAt | Compound index: state+created_at → lease UUIDs |
+| `0x0C` | CustomDomainIndex | Reverse index: custom_domain → CustomDomainTarget (lease_uuid + service_name) |
 
 ### Params
 
@@ -162,7 +211,8 @@ Module parameters stored at key `0x00`:
 | min_lease_duration | uint64 | Minimum lease duration in seconds (default: 3600 = 1 hour) |
 | max_pending_leases_per_tenant | uint64 | Maximum pending leases per tenant (default: 10) |
 | pending_timeout | uint64 | Seconds before pending lease expires (default: 1800 = 30 minutes, min: 60, max: 86400) |
-| allowed_list | []string | List of addresses allowed to create leases on behalf of tenants |
+| allowed_list | []string | List of addresses allowed to create leases on behalf of tenants and to set lease custom_domains |
+| reserved_domain_suffixes | []string | DNS suffixes (each beginning with `.`) that tenants are forbidden from claiming via `set-item-custom-domain`. Used to gate provider wildcard zones. Tunable via governance. |
 
 **Validation Constraints:**
 - `max_leases_per_tenant`: Must be > 0 and ≤ 10,000
@@ -170,6 +220,7 @@ Module parameters stored at key `0x00`:
 - `min_lease_duration`: Must be > 0 and ≤ 2,592,000 (30 days)
 - `max_pending_leases_per_tenant`: Must be > 0 and ≤ 1,000
 - `pending_timeout`: Must be between 60 seconds (1 minute) and 86400 seconds (24 hours)
+- `reserved_domain_suffixes`: Each entry must begin with `.`, the substring after the dot must be a valid FQDN, no duplicates
 
 **Note:** There is no global `denom` parameter. Each SKU defines its own denomination in its `base_price`, enabling multi-denom billing.
 
@@ -186,6 +237,7 @@ These values are compile-time constants and cannot be changed via governance:
 | `MaxBatchLeaseSize` | 100 | Hard limit for any batch operation. For provider-wide withdraw: configurable via `--limit` up to this value. For specific lease operations: maximum UUIDs per call. |
 | `MaxRejectionReasonLength` | 256 | Maximum characters for lease rejection reason |
 | `MaxClosureReasonLength` | 256 | Maximum characters for lease closure reason |
+| `MaxCustomDomainLength` | 253 | Maximum bytes for `LeaseItem.custom_domain` (RFC 1035 max FQDN length) |
 | `MaxDurationSeconds` | 3,153,600,000 (100 years) | Maximum lease duration for accrual calculations (overflow protection). Defined in `keeper/accrual.go`. |
 | `CreditAccountAddressPrefix` | `billing/credit/` | Prefix used for deterministic credit address derivation |
 | `DefaultProviderWithdrawableQueryLimit` | 100 | Default limit for ProviderWithdrawable query |
@@ -239,6 +291,9 @@ Leases stored at key prefix `0x01`:
 | quantity | uint64 | Number of instances |
 | locked_price | Coin | Price locked at creation (per second rate, includes denom) |
 | service_name | string | Optional DNS-label for stack deployments (all-or-nothing per lease, unique within lease) |
+| custom_domain | string | Optional FQDN (≤253 bytes) routed to this item by the provider. Mutable via `MsgSetItemCustomDomain`. Globally unique while the lease is PENDING/ACTIVE; the keeper enforces uniqueness through the `CustomDomainIndex` reverse-index. |
+
+> **Note on `service_name` and `custom_domain`:** these two fields are compute-specific and live on `LeaseItem` today as a pragmatic shortcut. When a non-compute lease kind ships, both fields will be migrated to a future `x/deployment` module via a state migration (tracked: ENG-80).
 
 ### CreditAccount
 
@@ -339,6 +394,7 @@ The billing module supports the following transaction messages:
 | `MsgCancelLease` | Tenant cancels their own pending lease |
 | `MsgCloseLease` | Close an active lease |
 | `MsgWithdraw` | Withdraw accrued funds (specific leases or provider-wide) |
+| `MsgSetItemCustomDomain` | Set or clear `custom_domain` on a specific lease item (tenant / authority / `allowed_list`) |
 | `MsgUpdateParams` | Update module parameters (authority only) |
 
 For detailed message definitions, request/response formats, and CLI usage, see [API Reference](docs/API.md#cli-commands).
@@ -359,6 +415,7 @@ For detailed message definitions, request/response formats, and CLI usage, see [
 | CreditAddress | Derive credit address for a tenant |
 | WithdrawableAmount | Get withdrawable amount for a lease |
 | ProviderWithdrawable | Get total withdrawable for a provider |
+| LeaseByCustomDomain | Look up the active or pending lease that has claimed a given custom_domain (and the `service_name` of the matching item) |
 
 **Events**: See [API Reference - Events](docs/API.md#events) for the complete list of events emitted by this module.
 
@@ -395,6 +452,7 @@ For detailed authorization matrix, see [API Reference - Authorization](docs/API.
 - **Cancel Lease**: Tenant (own pending leases only)
 - **Close Lease**: Tenant, Provider, or Authority
 - **Withdraw**: Provider or Authority
+- **Set Item Custom Domain**: Tenant (own leases), Authority, or any address in `params.allowed_list`
 
 ## Integration with SKU Module
 

--- a/x/billing/README.md
+++ b/x/billing/README.md
@@ -107,7 +107,7 @@ HTTP-01. Domains are set or cleared after lease creation via
 - Each label is RFC 1123 (1-63 alphanumerics + hyphens, no leading/trailing
   hyphen).
 - The TLD label must contain at least one non-digit (rejects raw IPs).
-- No scheme (`://`), no `/ \t \s @ * ? #`, no leading or trailing dot.
+- No scheme (`://`), no leading or trailing dot, and none of the literal characters `/`, space, `\t` (tab), `@`, `*`, `?`, `#`.
 
 **Reserved suffixes** (`params.reserved_domain_suffixes`). Tenants cannot
 claim a domain that matches any reserved suffix. Each suffix entry must begin

--- a/x/billing/docs/API.md
+++ b/x/billing/docs/API.md
@@ -428,7 +428,7 @@ manifestd tx billing set-item-custom-domain 01902a9b-1234-7000-8000-000000000001
 
 **Notes:**
 - Emits `lease_custom_domain_set` (with `set_by` ∈ `{tenant, authority, allowed}`) on a successful set, or `lease_custom_domain_cleared` on clear. No event is emitted for an idempotent re-set or a clear of an already-empty domain.
-- Domain is normalised on write: lowercased and trimmed.
+- The transaction requires lowercase `custom_domain` — `MsgSetItemCustomDomain.ValidateBasic()` rejects mixed case before the keeper runs. Lower-case any user-supplied input client-side. The keeper does its own `strings.ToLower(strings.TrimSpace(...))` as defence-in-depth on the storage path, but you can't rely on it as a normalisation point for input.
 - Closing, rejecting, expiring, or auto-closing the lease frees the index entry automatically.
 
 ---

--- a/x/billing/docs/API.md
+++ b/x/billing/docs/API.md
@@ -391,6 +391,48 @@ echo "All withdrawals complete"
 
 ---
 
+#### set-item-custom-domain
+
+Set or clear the `custom_domain` on a specific lease item, addressed by `service_name`. Available since v2.1.0.
+
+```bash
+manifestd tx billing set-item-custom-domain [lease-uuid] [service-name] [domain] [flags]
+```
+
+**Arguments:**
+| Argument | Type | Description |
+|----------|------|-------------|
+| lease-uuid | string | UUID of the lease that owns the target item |
+| service-name | string | `service_name` of the target item; pass `""` for a 1-item legacy lease |
+| domain | string | FQDN to set, or `""` to clear |
+
+**Examples:**
+```bash
+# 1-item legacy lease (item.service_name == "")
+manifestd tx billing set-item-custom-domain 01902a9b-1234-7000-8000-000000000001 "" app.example.com --from tenant-key
+
+# multi-item lease, target the "web" item
+manifestd tx billing set-item-custom-domain 01902a9b-1234-7000-8000-000000000001 web app.example.com --from tenant-key
+
+# clear the domain on the "web" item
+manifestd tx billing set-item-custom-domain 01902a9b-1234-7000-8000-000000000001 web "" --from tenant-key
+```
+
+**Constraints:**
+- Sender must be the lease tenant, the module authority, or an address in `params.allowed_list`.
+- Lease must be in `PENDING` or `ACTIVE` state. Closed/rejected/expired leases are immutable.
+- Multi-item legacy leases (no `service_name`s) cannot set `custom_domain` — recreate in service-name mode.
+- Domain must pass `IsValidFQDN`: 1–253 bytes, lowercase, ≥ 1 dot separator, each label is RFC 1123 (1–63 alphanumerics + hyphens, no leading/trailing hyphen), TLD has at least one non-digit, no scheme/path/whitespace/`@`/`*`/`?`/`#`/leading or trailing dot.
+- Domain must not match any entry in `params.reserved_domain_suffixes` (case-insensitive, label-boundary suffix check; entries also match their apex).
+- Domain must be globally unique across all PENDING/ACTIVE leases. Re-setting the same domain on the same item is idempotent (no state change, no event).
+
+**Notes:**
+- Emits `lease_custom_domain_set` (with `set_by` ∈ `{tenant, authority, allowed}`) on a successful set, or `lease_custom_domain_cleared` on clear. No event is emitted for an idempotent re-set or a clear of an already-empty domain.
+- Domain is normalised on write: lowercased and trimmed.
+- Closing, rejecting, expiring, or auto-closing the lease frees the index entry automatically.
+
+---
+
 #### update-params
 
 Update module parameters (authority only).
@@ -411,19 +453,31 @@ manifestd tx billing update-params [max-leases-per-tenant] [max-items-per-lease]
 **Flags:**
 | Flag | Type | Description |
 |------|------|-------------|
-| --allowed-list | string | Comma-separated allowed addresses (optional) |
+| --allowed-list | string | Comma-separated addresses with privileged authority for `create-lease-for-tenant` and `set-item-custom-domain`. **Preserve-on-omit**: omit the flag to round-trip the current on-chain value unchanged. Pass `--allowed-list=""` to explicitly clear. |
+| --reserved-domain-suffixes | string | Comma-separated DNS suffixes (each beginning with `.`) that tenants are forbidden from claiming via `set-item-custom-domain`. Same **preserve-on-omit** semantics as `--allowed-list`. |
 
-**Example:**
+**Examples:**
 ```bash
+# Update only numeric params; allowed_list and reserved_domain_suffixes are preserved unchanged.
 manifestd tx billing update-params \
-  100 \
-  20 \
-  3600 \
-  10 \
-  1800 \
+  100 20 3600 10 1800 \
+  --from authority
+
+# Update numeric params and overwrite both lists.
+manifestd tx billing update-params \
+  100 20 3600 10 1800 \
   --allowed-list "manifest1abc...,manifest1def..." \
+  --reserved-domain-suffixes ".barney0.manifest0.net,.lifted.app" \
+  --from authority
+
+# Explicitly clear reserved_domain_suffixes (numeric-only updates would preserve it).
+manifestd tx billing update-params \
+  100 20 3600 10 1800 \
+  --reserved-domain-suffixes="" \
   --from authority
 ```
+
+**Reserved-suffix validation:** each entry must begin with `.`, the substring after the dot must be a valid FQDN, and duplicates are rejected.
 
 ---
 
@@ -446,7 +500,8 @@ manifestd query billing params
     "min_lease_duration": "3600",
     "max_pending_leases_per_tenant": "10",
     "pending_timeout": "1800",
-    "allowed_list": []
+    "allowed_list": [],
+    "reserved_domain_suffixes": []
   }
 }
 ```
@@ -867,6 +922,45 @@ manifestd query billing credit-estimate manifest1abc...
 **Limitations:**
 - **Maximum 100 leases processed**: If a tenant has more than 100 active leases, only the first 100 are included in the calculation. The `active_lease_count` will show the actual count, but rates may be underestimated for tenants with >100 leases.
 - **Does not account for pending withdrawals**: The estimate uses current balance, not accounting for any unsettled accrued amounts from existing leases.
+
+---
+
+#### lease-by-domain
+
+Look up the active or pending lease that has claimed a given `custom_domain`, and the `service_name` of the matching item.
+
+```bash
+manifestd query billing lease-by-domain [custom-domain]
+```
+
+**Arguments:**
+| Argument | Type | Description |
+|----------|------|-------------|
+| custom-domain | string | FQDN to look up (case-insensitive; the chain stores the canonical lower-cased form) |
+
+**Example:**
+```bash
+manifestd query billing lease-by-domain app.example.com
+```
+
+**Response:**
+```json
+{
+  "lease": {
+    "uuid": "01902a9b-1234-7000-8000-000000000001",
+    "tenant": "manifest1abc...",
+    "provider_uuid": "01912345-6789-7abc-8def-fedcba987654",
+    "items": [ /* ... */ ],
+    "state": "LEASE_STATE_ACTIVE"
+  },
+  "service_name": "web"
+}
+```
+
+**Notes:**
+- Returns the lease and the `service_name` of the LeaseItem that owns the domain. For a 1-item legacy lease the `service_name` is `""`.
+- Returns gRPC `NotFound` (CLI: error) when no PENDING/ACTIVE item has claimed the domain.
+- Backed by the `CustomDomainIndex` reverse-lookup (O(1)); domains held by closed/rejected/expired leases are not indexed.
 - **Assumes constant rate**: The estimate assumes all current leases continue at their current rates. Actual duration may differ if leases are closed or new leases are created.
 
 ---
@@ -1139,6 +1233,44 @@ message MsgUpdateParamsResponse {}
 
 ---
 
+#### MsgSetItemCustomDomain
+
+Set or clear `custom_domain` on a specific lease item identified by `service_name`. Available since v2.1.0.
+
+**Authorisation.** `sender` must be the lease tenant, the module authority, or an address in `params.allowed_list`.
+
+**Request:**
+```protobuf
+message MsgSetItemCustomDomain {
+  string sender = 1;        // Tenant, authority, or allowed_list member
+  string lease_uuid = 2;    // Target lease (must be PENDING or ACTIVE)
+  string service_name = 3;  // Item addressing key; "" for a 1-item legacy lease
+  string custom_domain = 4; // FQDN to set, or "" to clear
+}
+```
+
+**Response:**
+```protobuf
+message MsgSetItemCustomDomainResponse {}
+```
+
+**Behaviour notes:**
+- Lease state must be `PENDING` or `ACTIVE` (`ErrLeaseNotEditable` otherwise).
+- Multi-item legacy leases (no `service_name`s) cannot use `custom_domain` (`ErrAmbiguousLeaseItem`).
+- Empty `custom_domain` clears the field and removes the `CustomDomainIndex` entry.
+- `custom_domain` is normalised on write (`strings.ToLower` + `TrimSpace`).
+- A non-empty domain is validated by `IsValidFQDN` and rejected if it matches any `params.reserved_domain_suffixes` entry.
+- Re-setting the same domain on the same `(lease_uuid, service_name)` is idempotent (no event, no state change).
+- Cross-lease and within-lease cross-item collisions are rejected with `ErrCustomDomainAlreadyClaimed`.
+
+**Emitted events:**
+- `lease_custom_domain_set` on a successful set.
+- `lease_custom_domain_cleared` on a successful clear (with the previous value in `custom_domain`).
+
+Both carry attributes `lease_uuid`, `tenant`, `service_name`, `custom_domain`, `set_by`. `set_by` ∈ `{tenant, authority, allowed}` records which authorisation path matched.
+
+---
+
 ### Query Service
 
 The Query service provides read-only access to state.
@@ -1158,6 +1290,7 @@ service Query {
   rpc CreditAddress(QueryCreditAddressRequest) returns (QueryCreditAddressResponse);
   rpc WithdrawableAmount(QueryWithdrawableAmountRequest) returns (QueryWithdrawableAmountResponse);
   rpc ProviderWithdrawable(QueryProviderWithdrawableRequest) returns (QueryProviderWithdrawableResponse);
+  rpc LeaseByCustomDomain(QueryLeaseByCustomDomainRequest) returns (QueryLeaseByCustomDomainResponse);
 }
 ```
 
@@ -1272,6 +1405,34 @@ message QueryCreditAddressResponse {
 
 ---
 
+#### QueryLeaseByCustomDomain
+
+Look up the PENDING/ACTIVE lease (and the `service_name` of the matching item) that owns a given `custom_domain`.
+
+**Endpoint:** `liftedinit.billing.v1.Query/LeaseByCustomDomain`
+
+**Request:**
+```protobuf
+message QueryLeaseByCustomDomainRequest {
+  string custom_domain = 1;
+}
+```
+
+**Response:**
+```protobuf
+message QueryLeaseByCustomDomainResponse {
+  Lease lease = 1;
+  string service_name = 2;  // "" for a 1-item legacy lease
+}
+```
+
+**Notes:**
+- The query lower-cases and trims `custom_domain` before lookup.
+- Backed by `CustomDomainIndex` (O(1)). Closing/rejecting/expiring/auto-closing the lease frees the index entry, so domains held by terminal leases are not returned.
+- Returns gRPC `NotFound` when no claim exists.
+
+---
+
 ## REST API
 
 REST endpoints are available via gRPC-gateway.
@@ -1298,6 +1459,7 @@ http://localhost:1317/liftedinit/billing/v1
 | GET | `/credit-address/{tenant}` | Derive credit address |
 | GET | `/lease/{lease_uuid}/withdrawable` | Get withdrawable amount |
 | GET | `/provider/{provider_uuid}/withdrawable` | Get provider total withdrawable |
+| GET | `/lease/by-domain/{custom_domain}` | Look up lease by custom domain (v2.1.0+) |
 
 ### Examples
 
@@ -1366,6 +1528,21 @@ message LeaseItem {
   uint64 quantity = 2;                         // Number of instances
   cosmos.base.v1beta1.Coin locked_price = 3;   // Per-second rate locked at creation
   string service_name = 4;                     // Optional RFC 1123 DNS label for stack deployments
+  string custom_domain = 5;                    // Optional FQDN routed to this item (v2.1.0+, max 253 bytes)
+}
+```
+
+**Field notes:**
+- `custom_domain`: Optional fully-qualified domain name routed to this item's container by the provider. Set or cleared via `MsgSetItemCustomDomain` (not via lease creation). Validated by `IsValidFQDN` (≤253 bytes, lowercase, ≥1 dot, RFC 1123 labels, non-numeric TLD) and rejected if it matches any `params.reserved_domain_suffixes` entry. Globally unique across PENDING/ACTIVE leases — enforced by the `CustomDomainIndex` reverse-lookup. Cleared automatically when the lease closes/rejects/expires.
+
+### CustomDomainTarget
+
+The value type stored in `CustomDomainIndex` (the reverse lookup keyed by domain). Returned indirectly by `QueryLeaseByCustomDomain`.
+
+```protobuf
+message CustomDomainTarget {
+  string lease_uuid = 1;
+  string service_name = 2;  // "" for a 1-item legacy lease
 }
 ```
 
@@ -1401,14 +1578,19 @@ message CreditAccount {
 
 ```protobuf
 message Params {
-  uint64 max_leases_per_tenant = 3;
-  repeated string allowed_list = 4;
-  uint64 max_items_per_lease = 5;
-  uint64 min_lease_duration = 6;
-  uint64 max_pending_leases_per_tenant = 7;
-  uint64 pending_timeout = 8;
+  uint64 max_leases_per_tenant = 1;
+  repeated string allowed_list = 2;
+  uint64 max_items_per_lease = 3;
+  uint64 min_lease_duration = 4;
+  uint64 max_pending_leases_per_tenant = 5;
+  uint64 pending_timeout = 6;
+  repeated string reserved_domain_suffixes = 7; // v2.1.0+
 }
 ```
+
+**Field notes:**
+- `allowed_list`: Addresses with privileged authority for `MsgCreateLeaseForTenant` and `MsgSetItemCustomDomain`, in addition to the module authority.
+- `reserved_domain_suffixes`: DNS suffixes (each must begin with `.`) that tenants are forbidden from claiming as a `LeaseItem.custom_domain`. Match is case-insensitive at a label boundary, plus the apex (e.g. `.foo.example` matches both `app.foo.example` and `foo.example`). Each entry's substring after the leading dot must itself be a valid FQDN. Tunable via `MsgUpdateParams`.
 
 ---
 
@@ -1433,6 +1615,10 @@ The billing module emits the following events for state changes:
 | `provider_withdraw` | lease_uuid, provider_uuid, payout_address | Provider withdrawal from single lease |
 | `batch_withdraw` | lease_count, provider_uuid, amount, payout_address, auto_closed | Batch summary when multiple leases withdrawn from |
 | `params_updated` | | Module parameters updated |
+| `lease_custom_domain_set` | lease_uuid, tenant, service_name, custom_domain, set_by | `LeaseItem.custom_domain` set or changed (v2.1.0+) |
+| `lease_custom_domain_cleared` | lease_uuid, tenant, service_name, custom_domain (previous value), set_by | `LeaseItem.custom_domain` cleared (v2.1.0+) |
+
+**Custom-domain `set_by` attribute:** records the role under which the call was authorised. One of `tenant`, `authority`, `allowed`. No event is emitted for an idempotent re-set or a clear of an already-empty domain.
 
 **Special Case - Withdrawal Auto-Close:** When a `MsgWithdraw` operation discovers the lease's credit is exhausted (balance = 0), it automatically closes the lease. In this case, the `provider_withdraw` event includes an additional `auto_closed: "true"` attribute and `amount: "0"` to indicate no funds were transferred. Note that the `payout_address` attribute is omitted in this case since no transfer occurred.
 
@@ -1504,6 +1690,11 @@ manifestd query tx [txhash] --output json | jq -r '.logs[0].events[] | select(.t
 | `ErrInvalidClosureReason` | 26 | Closure reason too long (max 256 chars) |
 | `ErrInvalidMetaHash` | 27 | Meta hash exceeds maximum length (max 64 bytes) |
 | `ErrInvalidServiceName` | 28 | Invalid service name (must be RFC 1123 DNS label: 1-63 lowercase alphanumeric/hyphens, no leading/trailing hyphen) |
+| `ErrInvalidCustomDomain` | 29 | Invalid `LeaseItem.custom_domain` (failed `IsValidFQDN` checks, exceeded 253 bytes, or matched a reserved suffix) |
+| `ErrCustomDomainAlreadyClaimed` | 30 | Domain is already claimed by another (lease, item) pair, or by a different item on the same lease |
+| `ErrLeaseNotEditable` | 31 | Lease is not in PENDING or ACTIVE state — `custom_domain` cannot be edited on closed/rejected/expired leases |
+| `ErrLeaseItemNotFound` | 32 | No lease item matched the supplied `service_name` |
+| `ErrAmbiguousLeaseItem` | 33 | Lookup by `service_name` matched more than one item — happens for multi-item legacy leases (no `service_name`s); recreate the lease in service-name mode |
 
 **Note on Reserved Codes:** Error codes 7 and 20 are explicitly reserved to maintain stable error code assignments across module versions.
 
@@ -1512,7 +1703,7 @@ manifestd query tx [txhash] --output json | jq -r '.logs[0].events[] | select(.t
 - Error codes in logs and metrics remain comparable across versions
 - New errors get the next available number (29+) rather than reusing gaps
 
-**For developers:** Never assign new errors to reserved codes. Always use the next sequential number after the highest assigned code.
+**For developers:** Never assign new errors to reserved codes. Always use the next sequential number after the highest assigned code (currently 33).
 
 ---
 
@@ -1528,6 +1719,7 @@ manifestd query tx [txhash] --output json | jq -r '.logs[0].events[] | select(.t
 | CancelLease | ✓ (own leases) | ✗ | ✗ | ✗ |
 | CloseLease | ✓ (own leases) | ✓ | ✓ | ✗ |
 | Withdraw | ✗ | ✓ | ✓ | ✗ |
+| SetItemCustomDomain | ✓ (own leases) | ✗ | ✓ | ✓ |
 | UpdateParams | ✗ | ✗ | ✓ | ✗ |
 
 **Notes:**

--- a/x/billing/docs/ARCHITECTURE.md
+++ b/x/billing/docs/ARCHITECTURE.md
@@ -541,7 +541,7 @@ The matching role is recorded in the emitted event's `set_by` attribute (`tenant
 
 A non-empty domain must pass `IsValidFQDN`:
 - length 1–253 bytes (`MaxCustomDomainLength`);
-- lowercase only (the keeper lower-cases & trims before validation, so callers may submit mixed case);
+- **lowercase only — the transaction is rejected at `MsgSetItemCustomDomain.ValidateBasic()` (which calls `IsValidFQDN` directly) before reaching the keeper. Callers must lower-case `custom_domain` client-side before signing.** The keeper additionally `strings.ToLower(strings.TrimSpace(...))`s the value as defence-in-depth on the storage path, but that normalisation never runs against mixed-case input in practice;
 - ≥ 1 dot separator (rejects bare hostnames);
 - each label is RFC 1123 (1–63 alphanumerics + hyphens, no leading/trailing hyphen);
 - the TLD label has at least one non-digit character (rejects raw IPv4);

--- a/x/billing/docs/ARCHITECTURE.md
+++ b/x/billing/docs/ARCHITECTURE.md
@@ -137,10 +137,15 @@ Individual line items within a lease:
 | `quantity` | `uint64` | Number of units (e.g., 5 instances) |
 | `locked_price` | `Coin` | Per-second price locked at lease creation (includes denom) |
 | `service_name` | `string` | Optional RFC 1123 DNS label for stack deployments (1-63 lowercase alphanumeric/hyphens) |
+| `custom_domain` | `string` | Optional FQDN (≤253 bytes) routed to this item by the provider — see [Custom Domains](#custom-domains-per-item) (v2.1.0+) |
 
 **Note**: The `locked_price` is pre-computed at lease creation as the per-second rate for billing calculations. This is derived from the SKU's base price and unit at the time of lease creation. The denomination is preserved from the SKU's `base_price`, enabling multi-denom billing.
 
 **Service Names**: When `service_name` is set, all items in the lease must have one (all-or-nothing). Uniqueness shifts from `sku_uuid` to `service_name`, allowing the same SKU to appear multiple times for different named services (e.g., "web" and "db" both using a docker-small SKU). This enables stack deployments where the off-chain orchestrator maps each service to its container.
+
+**Custom Domains**: `custom_domain` is mutable post-creation via `MsgSetItemCustomDomain` (`service_name` and the rest of the lease are immutable). Globally unique while the lease is PENDING/ACTIVE — enforced through the `CustomDomainIndex` reverse-index that maps `domain → CustomDomainTarget{lease_uuid, service_name}`. See [Custom Domains](#custom-domains-per-item) for the full flow.
+
+> **Compute-specific fields:** `service_name` and `custom_domain` are pragmatic shortcuts that live on `LeaseItem` today. They will migrate to a future `x/deployment` module once a non-compute lease kind ships (tracked: ENG-80).
 
 ### LeaseState Enum
 
@@ -198,6 +203,7 @@ graph LR
 | `LeasesByTenantState` | `(AccAddress, int32, string)` | `bool` | Compound tenant+state → leases index |
 | `LeasesBySKU` | `(string, string)` | `bool` | Many-to-many SKU → leases index |
 | `LeasesByStateCreatedAt` | `(int32, time.Time, string)` | `bool` | Compound state+created_at → leases index (time-ordered) |
+| `CustomDomainIndex` | `string` (lower-cased domain) | `CustomDomainTarget` | Reverse lookup `custom_domain → (lease_uuid, service_name)` for O(1) `QueryLeaseByCustomDomain`. Reconciled by `SetLease` whenever lease items change; freed on close/reject/expire/auto-close. |
 | `Params` | - | `Params` | Module parameters |
 
 ## Core Flows
@@ -508,6 +514,114 @@ sequenceDiagram
         end
     end
 ```
+
+## Custom Domains (per-item)
+
+> Available since v2.1.0 (PR #152). Implemented in `x/billing/keeper/custom_domain.go` and `x/billing/types/msgs.go` (`IsValidFQDN`, `MatchesReservedSuffix`).
+
+### Purpose
+
+Each `LeaseItem` can carry an optional `custom_domain` — an FQDN the provider routes to that item's container with a TLS cert provisioned via HTTP-01. Domains are claimed and released entirely on-chain: the provider runs `QueryLeaseByCustomDomain` against incoming HTTP host headers and trusts the returned `(lease_uuid, service_name)` as the routing target.
+
+### State
+
+- `CustomDomainIndex` (collection prefix `0x0C`): `string → CustomDomainTarget{lease_uuid, service_name}`. Keys are the canonical (lower-cased, trimmed) domain. Only PENDING/ACTIVE leases hold entries.
+- The same `custom_domain` string is also stored on `LeaseItem.custom_domain` so the lease record carries the claim independently of the index. `SetLease` reconciles both representations on every write.
+
+### Authorisation
+
+`MsgSetItemCustomDomain` is signed by `sender` and accepted when:
+1. `sender == lease.tenant`, **or**
+2. `sender == module authority`, **or**
+3. `sender ∈ params.allowed_list`.
+
+The matching role is recorded in the emitted event's `set_by` attribute (`tenant` / `authority` / `allowed`) so off-chain auditors can attribute changes.
+
+### Validation
+
+A non-empty domain must pass `IsValidFQDN`:
+- length 1–253 bytes (`MaxCustomDomainLength`);
+- lowercase only (the keeper lower-cases & trims before validation, so callers may submit mixed case);
+- ≥ 1 dot separator (rejects bare hostnames);
+- each label is RFC 1123 (1–63 alphanumerics + hyphens, no leading/trailing hyphen);
+- the TLD label has at least one non-digit character (rejects raw IPv4);
+- no scheme (`://`), no `/`, ` `, `\t`, `@`, `*`, `?`, `#`;
+- no leading or trailing dot.
+
+It must also pass `MatchesReservedSuffix(params.ReservedDomainSuffixes)` ⇒ `false`. Each reserved-suffix entry must begin with `.`; a domain matches when it ends with the suffix at a label boundary, or equals the suffix's apex (`.foo.example` matches both `app.foo.example` and `foo.example`). The check is case-insensitive and **fail-closed** on malformed entries (so a corrupted params slice can't accidentally permit reserved domains).
+
+### Lookup contract
+
+The keeper resolves the target item by `service_name`:
+
+| Lease shape | Caller passes | Match |
+|---|---|---|
+| 1-item legacy (item.service_name `""`) | `service_name == ""` | the single item |
+| Multi-item, service-name mode | `service_name == "web"` | the unique item with that name |
+| Multi-item legacy (no service_names) | any value | rejected with `ErrAmbiguousLeaseItem` — recreate in service-name mode |
+
+The lookup is wrapped in a defensive guard: even though `ValidateLeaseItems` and the genesis check prevent multi-item legacy leases from existing, the keeper rejects them at the lookup site rather than relying on construction-time invariants.
+
+### Set / clear flow (`MsgSetItemCustomDomain`)
+
+```mermaid
+sequenceDiagram
+    participant Sender
+    participant MsgServer
+    participant Keeper
+    participant Lease as Lease.Items[i]
+    participant Index as CustomDomainIndex
+
+    Sender->>MsgServer: MsgSetItemCustomDomain(lease_uuid, service_name, domain)
+    MsgServer->>Keeper: GetLease, IsAuthorizedForTenant
+    alt unauthorised
+        Keeper-->>Sender: ErrUnauthorized
+    end
+    alt lease state ∉ {PENDING, ACTIVE}
+        Keeper-->>Sender: ErrLeaseNotEditable
+    end
+    Keeper->>Lease: findLeaseItemByServiceName
+    alt 0 matches
+        Keeper-->>Sender: ErrLeaseItemNotFound
+    else >1 matches (legacy multi-item)
+        Keeper-->>Sender: ErrAmbiguousLeaseItem
+    end
+    alt domain == ""
+        Keeper->>Lease: clear custom_domain
+        Keeper->>Index: SetLease reconciles (drops old key)
+        Keeper-->>Sender: emit lease_custom_domain_cleared
+    else
+        Keeper->>Keeper: lower-case + trim, IsValidFQDN, MatchesReservedSuffix
+        Keeper->>Index: pre-flight Get(domain)
+        alt same (lease, item) already holds it
+            Keeper-->>Sender: idempotent no-op (no event)
+        else within-lease cross-item collision
+            Keeper-->>Sender: ErrCustomDomainAlreadyClaimed (in-lease)
+        else cross-lease collision
+            Keeper-->>Sender: ErrCustomDomainAlreadyClaimed (in-lease X)
+        else free
+            Keeper->>Lease: set custom_domain
+            Keeper->>Index: SetLease reconciles (writes new key)
+            Keeper-->>Sender: emit lease_custom_domain_set
+        end
+    end
+```
+
+The pre-flight uniqueness check is a UX layer: `SetLease`'s storage-level reconciliation is the defence-in-depth that prevents two simultaneous claims from racing through.
+
+### Index lifecycle
+
+`CustomDomainIndex` entries are created and freed exclusively through `SetLease`'s reconciliation pass. As a result:
+- closing a lease (`MsgCloseLease`, auto-close on credit exhaustion);
+- rejecting a lease (`MsgRejectLease`);
+- a tenant cancelling a pending lease (`MsgCancelLease`);
+- a pending lease expiring in EndBlocker;
+
+each free every `custom_domain` the lease held in a single SetLease call. Genesis import re-derives the index from `LeaseItem.custom_domain` values for PENDING/ACTIVE leases only.
+
+### Query
+
+`QueryLeaseByCustomDomain` is the only read path that uses the index. It lower-cases and trims the input domain before lookup so case-insensitive HTTP host headers work without per-caller normalisation. The response carries the full `Lease` plus the `service_name` of the matching item — for a 1-item legacy lease the `service_name` is `""`.
 
 ## Settlement Triggers
 

--- a/x/billing/docs/CAPABILITIES.md
+++ b/x/billing/docs/CAPABILITIES.md
@@ -31,6 +31,7 @@ This document provides a comprehensive overview of the Billing module's capabili
 | **Multi-Denom Support** | Credit accounts can hold multiple token types |
 | **Batch Operations** | Provider-wide withdrawal, batch acknowledge/reject |
 | **Pending Timeout** | Unacknowledged leases expire automatically (EndBlocker) |
+| **Per-Item Custom Domains** | Tenants attach FQDNs to lease items post-creation; provider routes traffic and provisions HTTP-01 TLS. Globally unique while the lease is PENDING/ACTIVE; reserved suffixes block claims on provider wildcard zones. (v2.1.0+) |
 
 ---
 
@@ -114,6 +115,7 @@ When credit is exhausted:
 | `CreditAddress` | Derive credit address for a tenant |
 | `WithdrawableAmount` | Accrued amount for a specific lease |
 | `ProviderWithdrawable` | Total withdrawable across all provider's leases |
+| `LeaseByCustomDomain` | Look up the PENDING/ACTIVE lease + item that owns a given `custom_domain` (v2.1.0+) |
 
 ---
 

--- a/x/manifest/README.md
+++ b/x/manifest/README.md
@@ -135,7 +135,7 @@ It is reserved but never written or read. Future versions may either drop it or 
 
 ## Queries
 
-The module exposes **no queries**. `proto/liftedinit/manifest/v1/query.proto` is `service Query {}` with no methods, and no query CLI subcommand exists. To inspect minted/burned supply, query `x/bank` directly:
+The module exposes **no queries**. `proto/liftedinit/manifest/v1/query.proto` is `service Query {}` with no methods. The `manifestd query manifest` parent command is still registered (it shows up in `manifestd query --help` for module-CLI wiring consistency), but it has no subcommands attached. To inspect minted/burned supply, query `x/bank` directly:
 
 ```bash
 manifestd query bank total --denom umfx

--- a/x/manifest/README.md
+++ b/x/manifest/README.md
@@ -112,8 +112,10 @@ message MsgBurnHeldBalanceResponse {}
 ```bash
 manifestd tx manifest burn-coins [coins,...] --from <admin-key>
 # Example (multi-denom burn):
-manifestd tx manifest burn-coins 50_000umfx,100othercoin --from authority
+manifestd tx manifest burn-coins 50000umfx,100othercoin --from authority
 ```
+
+> Unlike `payout`, `burn-coins` does **not** strip underscores from amounts — it parses the argument with `sdk.ParseCoinsNormalized` directly. Pass plain digits (e.g. `50000umfx`); `50_000umfx` would fail with `invalid decimal coin expression`.
 
 ## State
 

--- a/x/manifest/README.md
+++ b/x/manifest/README.md
@@ -148,16 +148,20 @@ manifestd query bank balances <authority-address>
 
 ## Errors
 
-Both message handlers return plain `fmt.Errorf` strings rather than registered `cosmossdk.io/errors`. Don't write client code that key-matches on numeric codes — match on substrings if you must distinguish failure modes:
+`x/manifest` does not register its own error codes (`errors.Register(ModuleName, …)` is not called anywhere in this module), so there are no `manifest`-typed numeric codes to match on. The handlers return errors in two layers:
 
-| Source | Substring | When |
-|---|---|---|
-| `msg_server.go` | `invalid authority; expected …, got …` | `msg.authority` ≠ `keeper.authority` |
-| `msg_server.go` | `invalid payout message:` / `invalid burn held message:` | `Validate()` failed |
-| `msgs.go::Validate` | `payouts cannot be empty` / `burn coins cannot be empty` | empty list |
-| `msgs.go::Validate` | `duplicate address: …` | `MsgPayout` has the same recipient twice |
-| `msgs.go::Validate` | `coin cannot be zero for address: …` | zero-amount payout pair |
-| `msg_server.go::BurnHeldBalance` | `not enough balance to burn …` | authority balance < `burn_coins` |
+1. **Outer wrapper** at the msg server (`x/manifest/keeper/msg_server.go`) — plain `fmt.Errorf` with stable prefix strings. The authority-mismatch check is a bare error; the validation and bank-keeper failures are wrapped with `%w` (preserving the underlying error chain). Substring-match the prefixes if you need to distinguish module-specific failure modes:
+
+   | Source | Substring | When |
+   |---|---|---|
+   | `msg_server.go` | `invalid authority; expected …, got …` | `msg.authority` ≠ `keeper.authority` |
+   | `msg_server.go` | `invalid payout message:` / `invalid burn held message:` | `Validate()` failed |
+   | `msgs.go::Validate` | `payouts cannot be empty` / `burn coins cannot be empty` | empty list |
+   | `msgs.go::Validate` | `duplicate address: …` | `MsgPayout` has the same recipient twice |
+   | `msgs.go::Validate` | `coin cannot be zero for address: …` | zero-amount payout pair |
+   | `msg_server.go::BurnHeldBalance` | `not enough balance to burn …` | authority balance < `burn_coins` |
+
+2. **Wrapped underlying errors** carry structured codes from upstream — `cosmossdk.io/errors`-typed errors from `Msg*.Validate()` (e.g. wrapping `sdk.AccAddressFromBech32`, coin validation), and SDK-typed errors from the bank keeper (e.g. `sdkerrors.ErrInsufficientFunds` underneath `not enough balance to burn …`). Use `errors.Is` / `errors.As` after unwrapping if you need to react to a specific upstream code rather than the wrapper string.
 
 ## Module-account permissions
 

--- a/x/manifest/README.md
+++ b/x/manifest/README.md
@@ -1,3 +1,202 @@
 # x/manifest
 
-The manifest module provides functionality for manual token minting/burning by the POA administrator.
+The `manifest` module gives the Proof-of-Authority admin a controlled mint-and-distribute primitive plus the matching burn primitive. On a PoS chain these would normally come from `x/mint`'s automatic inflation; on a PoA chain inflation is policy, not protocol, so this module replaces that BeginBlocker with two explicit transaction types.
+
+## Concepts
+
+### Why this module exists
+
+The standard Cosmos SDK `x/mint` module mints new supply every block based on a target inflation rate and bonded ratio. That model assumes a PoS economic loop. `manifest-1` runs Proof of Authority — there is no bonded ratio to target and no automatic inflation policy to enforce. Instead, the PoA admin (or admin group) decides when and how much to mint, and pays out stakeholders directly via `MsgPayout`.
+
+Concretely:
+
+```go
+// app/app.go module manager registration:
+app.ModuleManager.SetOrderBeginBlockers(
+    // minttypes.ModuleName, // we override with the manifest module logic
+    manifesttypes.ModuleName, // minter to stakeholders
+    ...
+)
+```
+
+The standard `x/mint` BeginBlocker is commented out. `x/manifest` occupies the same slot but **does not register a BeginBlocker** — minting only happens inside `MsgPayout` transactions. There is no time-based behaviour in this module.
+
+### What the authority can do
+
+| Operation | Effect on supply | Coin source / sink |
+|---|---|---|
+| `MsgPayout` | Increases | Mints fresh coins via the module's `Minter` permission, then sends to one or more recipient addresses |
+| `MsgBurnHeldBalance` | Decreases | Pulls coins from the **authority's own bank balance** into the module account, then burns them |
+
+`MsgBurnHeldBalance` does not let the authority burn arbitrary holders' balances — only coins already held in the authority address. To burn from somewhere else, fund the authority first.
+
+## Authorisation
+
+| Operation | Authority | Anyone else |
+|---|---|---|
+| `MsgPayout` | ✓ | ✗ |
+| `MsgBurnHeldBalance` | ✓ | ✗ |
+
+"Authority" means the address configured in `keeper.authority` at app wiring. On `manifest-1` this is the PoA admin (or, when wrapped in `x/group`, the group's policy address). The msg server compares `msg.authority` to `keeper.authority` byte-for-byte and rejects with a plain `fmt.Errorf("invalid authority; expected …, got …")` on mismatch.
+
+> **Operational risk:** the authority has uncapped mint power. There is no on-chain policy limiting payout amounts, payout frequency, or burnable amounts. Compromise of the PoA admin key means uncapped supply changes. Treat the admin as a multi-sig / x/group policy in production.
+
+## Messages
+
+| Message | Description |
+|---------|-------------|
+| `MsgPayout` | Mint new coins and distribute to a list of `(address, coin)` pairs. Authority only. |
+| `MsgBurnHeldBalance` | Burn coins held in the authority's own account. Authority only. |
+
+### MsgPayout
+
+```protobuf
+message MsgPayout {
+  string authority = 1;                     // must equal keeper.authority
+  repeated PayoutPair payout_pairs = 2;     // 1..N pairs
+}
+
+message PayoutPair {
+  string address = 1;                       // bech32 recipient
+  cosmos.base.v1beta1.Coin coin = 2;        // single coin (one denom per pair)
+}
+
+message MsgPayoutResponse {}
+```
+
+**Validation (`MsgPayout.Validate`):**
+- `authority` parses as bech32.
+- `payout_pairs` is non-empty.
+- Each pair's `address` parses as bech32.
+- Each pair's `coin` is non-zero and passes `Coin.Validate()`.
+- No duplicate `address` across pairs.
+
+**Behaviour (`Keeper.Payout`):**
+- For each pair, mint the coin into the `manifest` module account (`bankKeeper.MintCoins`).
+- Send from the module account to the recipient (`bankKeeper.SendCoinsFromModuleToAccount`).
+- Logs `Payout` per pair.
+
+**CLI:**
+```bash
+manifestd tx manifest payout [address:coin_amount,...] --from <admin-key>
+# Example (two recipients in one tx):
+manifestd tx manifest payout \
+  manifest1abc...:50_000umfx,manifest1xyz...:1_000_000umfx \
+  --from authority
+# Underscores in amounts are stripped client-side for readability.
+```
+
+### MsgBurnHeldBalance
+
+```protobuf
+message MsgBurnHeldBalance {
+  string authority = 1;                     // must equal keeper.authority — the burn source
+  repeated cosmos.base.v1beta1.Coin burn_coins = 2;  // 1..N coins (any denom mix)
+}
+
+message MsgBurnHeldBalanceResponse {}
+```
+
+> The proto field is named `authority` (and the proto comment mistakenly calls it `sender`). The semantics are unambiguous: this is the address the coins are debited from, and it must equal `keeper.authority`.
+
+**Validation (`MsgBurnHeldBalance.Validate`):**
+- `authority` parses as bech32.
+- `burn_coins.Len() > 0`.
+- `burn_coins.Validate()` (no zero, no negative, no duplicates, sorted denoms).
+
+**Behaviour (`msgServer.BurnHeldBalance`):**
+- Move `burn_coins` from the authority account into the `manifest` module account (`bankKeeper.SendCoinsFromAccountToModule`). Insufficient balance fails with `not enough balance to burn …`.
+- Burn from the module account (`bankKeeper.BurnCoins`).
+
+**CLI:**
+```bash
+manifestd tx manifest burn-coins [coins,...] --from <admin-key>
+# Example (multi-denom burn):
+manifestd tx manifest burn-coins 50_000umfx,100othercoin --from authority
+```
+
+## State
+
+`x/manifest` is **stateless**:
+
+- `proto/liftedinit/manifest/v1/genesis.proto` defines `GenesisState {}` with no fields.
+- `Keeper.InitGenesis` and `Keeper.ExportGenesis` are no-ops returning empty state.
+
+There is one vestigial collection prefix in code:
+
+```go
+// x/manifest/types/keys.go
+var ParamsKey = collections.NewPrefix(0)
+```
+
+It is reserved but never written or read. Future versions may either drop it or use it for an explicit params struct (e.g. payout caps).
+
+## Queries
+
+The module exposes **no queries**. `proto/liftedinit/manifest/v1/query.proto` is `service Query {}` with no methods, and no query CLI subcommand exists. To inspect minted/burned supply, query `x/bank` directly:
+
+```bash
+manifestd query bank total --denom umfx
+manifestd query bank balances <authority-address>
+```
+
+## Events
+
+`x/manifest` does not emit custom events. Standard SDK events from the underlying bank operations (`coin_received`, `coin_spent`, `mint`, `burn`, `transfer`) are emitted by `x/bank` as the keeper makes its calls. Indexers should key off those rather than expecting `manifest`-typed events.
+
+## Errors
+
+Both message handlers return plain `fmt.Errorf` strings rather than registered `cosmossdk.io/errors`. Don't write client code that key-matches on numeric codes — match on substrings if you must distinguish failure modes:
+
+| Source | Substring | When |
+|---|---|---|
+| `msg_server.go` | `invalid authority; expected …, got …` | `msg.authority` ≠ `keeper.authority` |
+| `msg_server.go` | `invalid payout message:` / `invalid burn held message:` | `Validate()` failed |
+| `msgs.go::Validate` | `payouts cannot be empty` / `burn coins cannot be empty` | empty list |
+| `msgs.go::Validate` | `duplicate address: …` | `MsgPayout` has the same recipient twice |
+| `msgs.go::Validate` | `coin cannot be zero for address: …` | zero-amount payout pair |
+| `msg_server.go::BurnHeldBalance` | `not enough balance to burn …` | authority balance < `burn_coins` |
+
+## Module-account permissions
+
+`x/manifest`'s module account holds `{Minter, Burner}` permissions, granted in `app/app.go`:
+
+```go
+manifesttypes.ModuleName: {authtypes.Minter, authtypes.Burner},
+```
+
+This is what makes the bank keeper accept `MintCoins(types.ModuleName, …)` and `BurnCoins(types.ModuleName, …)` calls from this keeper. No other module can drive these — the permission is scoped per module account.
+
+> **Note:** the `mintkeeper.Keeper` is wired into `manifestkeeper.NewKeeper` and `manifestmodule.NewAppModule` but is never used by the public methods. This is dead-store, retained for potential future use. New callers should not assume the mint keeper does anything here.
+
+## CLI reference
+
+| Command | Purpose |
+|---|---|
+| `tx manifest payout [pairs]` | `MsgPayout` — see above |
+| `tx manifest burn-coins [coins]` | `MsgBurnHeldBalance` — see above |
+
+There are no `query manifest …` subcommands.
+
+## Type URLs / amino names
+
+| Type URL | Amino name |
+|---|---|
+| `/liftedinit.manifest.v1.MsgPayout` | `lifted/manifest/MsgPayout` |
+| `/liftedinit.manifest.v1.MsgBurnHeldBalance` | `lifted/manifest/MsgBurnHeldBalance` |
+
+`PayoutPair` (carried inside `MsgPayout`) uses the unusual amino name `lifted/manifest/payout-pair` (kebab-case). Both messages serialise their `Coin`s with amino encoding `legacy_coin` / `legacy_coins` for Ledger compatibility.
+
+## Genesis
+
+`GenesisState` is empty. There is no module-specific genesis tuning — adding the module to `app.ModuleManager` and configuring `keeper.authority` in `app.NewApp` is sufficient.
+
+## Related modules
+
+- [`x/poa`](https://github.com/strangelove-ventures/poa) — Provides the authority address used here. The PoA admin (or admin group) is the only valid `MsgPayout` / `MsgBurnHeldBalance` signer.
+- `x/bank` — Where minted coins land and where burned coins are pulled from. All supply changes show up in standard bank events and `bank total`.
+- [`x/sku`](../sku/README.md) and [`x/billing`](../billing/README.md) — These modules don't depend on `x/manifest`. They reuse the same authority pattern but maintain their own state.
+
+## Spec
+
+Earlier `spec/` notes ([01_concepts.md](./spec/01_concepts.md), [02_state.md](./spec/02_state.md)) covered subsets of this material; this README is the canonical reference and supersedes them.

--- a/x/manifest/spec/02_state.md
+++ b/x/manifest/spec/02_state.md
@@ -4,4 +4,8 @@ order: 2
 
 # State
 
-The `x/manifest` module is stateless.
+The `x/manifest` module has no genesis state and writes nothing on transactions: `GenesisState {}` is empty, and both `MsgPayout` and `MsgBurnHeldBalance` only mutate `x/bank` state via the module account's `Minter` / `Burner` permissions.
+
+A reserved key prefix exists at `types.ParamsKey = collections.NewPrefix(0)` but is currently unused. Treat the module as stateless until that prefix becomes populated by a future release.
+
+For the canonical, up-to-date description see [`x/manifest/README.md`](../README.md).

--- a/x/manifest/spec/README.md
+++ b/x/manifest/spec/README.md
@@ -1,16 +1,16 @@
-# `manifest`
+# `manifest` (legacy spec)
+
+> **The canonical reference is now [`../README.md`](../README.md).** These spec stubs are kept for historical context and short pointers; new material should land in the README.
 
 ## Abstract
 
-This document specifies the internal `x/manifest` module of The Lifted Initiative, Manifest Ledger.
+The `x/manifest` module provides:
+- Manual minting (`MsgPayout`) — the PoA admin mints fresh coins and disburses to a list of recipient addresses.
+- Manual burning (`MsgBurnHeldBalance`) — the PoA admin burns coins held in their own account.
 
-The `x/manifest` module provides the following abilities:
-- Manual minting of tokens
-- Manual burning of tokens
-
-The network inflation is not tied to a standard bonded ratio like typical proof-of-stake (PoS) systems, Instead it is up to chain admin(s) to decide given the nature of a proof-of-authority (PoA) chain.
+Network inflation is not driven by a bonded ratio as in PoS — it is decided by the chain admin(s). See [`../README.md`](../README.md) for the full operational model.
 
 ## Contents
 
-1. **[Concepts](01_concepts.md)**
-2. **[State](02_state.md)**
+1. **[Concepts](01_concepts.md)** — quick command summary.
+2. **[State](02_state.md)** — note that the module is effectively stateless.


### PR DESCRIPTION
This pull request updates documentation across several files to clarify and expand usage instructions, improve accuracy, and add details for both users and contributors. The most important changes are:

**Billing Module Documentation Improvements:**
- Added detailed documentation for new and existing billing commands in `MODULE.md`, including `set-item-custom-domain`, with syntax, parameters, and usage examples. Also clarified flag semantics for `update-params`, especially around list handling and reserved domain suffixes. [[1]](diffhunk://#diff-45f4ef1c23c418a59a9177ffce348138b6a54d2a30523a21a445a640ba3ee217R47-R56) [[2]](diffhunk://#diff-45f4ef1c23c418a59a9177ffce348138b6a54d2a30523a21a445a640ba3ee217R539-R557) [[3]](diffhunk://#diff-45f4ef1c23c418a59a9177ffce348138b6a54d2a30523a21a445a640ba3ee217L540-R573)

**Quickstart and SDK Integration in README:**
- Introduced a comprehensive "Quickstart" section in `README.md` for all user roles (validators, tenants, providers), with step-by-step CLI instructions and integration pointers.
- Added a section on the JavaScript/TypeScript SDK (`@manifest-network/manifestjs`), including installation and usage guidance for frontend and wallet developers. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L21-R30) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R39-R138) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R290-R301)

**Contribution and Issue Reporting Process:**
- Updated `CONTRIBUTING.md` with direct links to the correct GitHub Issues pages and clarified the pull request process, emphasizing the use of PR templates and CI requirements. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L16-R20) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L52-R63)

**Security Policy Clarification:**
- Revised `SECURITY.md` to clarify the responsible disclosure process, remove the outdated public GPG key, and specify how to request a per-disclosure GPG key. Expanded the scope list to include all relevant packages.

**Genesis and Post-Genesis Validator Instructions:**
- Improved `network/manifest-1/GENESIS.md` and `POST_GENESIS.md` with up-to-date instructions, reflecting the current mainnet status, accurate URLs, correct Cosmos SDK command usage, and hardware requirements. [[1]](diffhunk://#diff-338be8ef6470c4012996821cee521858fe323efd97ae0df484fb0723f65227c6L3-R7) [[2]](diffhunk://#diff-338be8ef6470c4012996821cee521858fe323efd97ae0df484fb0723f65227c6L28-R27) [[3]](diffhunk://#diff-338be8ef6470c4012996821cee521858fe323efd97ae0df484fb0723f65227c6L92-R107) [[4]](diffhunk://#diff-338be8ef6470c4012996821cee521858fe323efd97ae0df484fb0723f65227c6L117-R122) [[5]](diffhunk://#diff-338be8ef6470c4012996821cee521858fe323efd97ae0df484fb0723f65227c6L129-R134) [[6]](diffhunk://#diff-d05eb028958180709018e54c65aa01b2edd8b763d34308d7452ea2bad2610db2L1-R11)