### PR TITLE
chore: prepare v2.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DOCKER := $(shell which docker)
 LEDGER_ENABLED ?= true
 BINDIR ?= $(GOPATH)/bin
 BUILD_DIR = ./build
-VERSION ?= v2.1.1
+VERSION ?= v2.2.0
 GO ?= go
 GOROOT := $(shell $(GO) env GOROOT)
 export GOROOT

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -405,8 +405,8 @@ Common subscriptions for a provider control plane:
 | New pending leases for me | `lease_created.provider_uuid='<UUID>'` |
 | Tenants cancelling pending leases | `lease_cancelled.provider_uuid='<UUID>'` |
 | Auto-close on credit exhaustion | `lease_auto_closed.provider_uuid='<UUID>'` |
-| Domain set on my leases | `lease_custom_domain_set.provider_uuid='<UUID>'` (v2.1.1+) |
-| Domain cleared on my leases | `lease_custom_domain_cleared.provider_uuid='<UUID>'` (v2.1.1+) |
+| Domain set on my leases | `lease_custom_domain_set.provider_uuid='<UUID>'` (v2.2.0+) |
+| Domain cleared on my leases | `lease_custom_domain_cleared.provider_uuid='<UUID>'` (v2.2.0+) |
 
 The full event catalogue and attributes live in [`x/billing/docs/API.md#events`](../x/billing/docs/API.md#events).
 

--- a/interchaintest/chain_upgrade_test.go
+++ b/interchaintest/chain_upgrade_test.go
@@ -30,7 +30,7 @@ var (
 	// baseChain is the current version of the chain that will be upgraded from
 	baseChain = ibc.DockerImage{
 		Repository: "ghcr.io/manifest-network/manifest-ledger",
-		Version:    "2.1.0",
+		Version:    "2.1.1",
 		UIDGID:     "1025:1025",
 	}
 
@@ -126,7 +126,7 @@ func TestBasicManifestUpgrade(t *testing.T) {
 	haltHeight := height + haltHeightDelta
 
 	// The upgrade name must match app.Version() in the new binary
-	upgradeName := "v2.1.1"
+	upgradeName := "v2.2.0"
 
 	t.Logf("Upgrade name: %s", upgradeName)
 	t.Logf("Current height: %d, halt height: %d", height, haltHeight)

--- a/x/billing/docs/API.md
+++ b/x/billing/docs/API.md
@@ -1615,8 +1615,8 @@ The billing module emits the following events for state changes:
 | `provider_withdraw` | lease_uuid, provider_uuid, payout_address | Provider withdrawal from single lease |
 | `batch_withdraw` | lease_count, provider_uuid, amount, payout_address, auto_closed | Batch summary when multiple leases withdrawn from |
 | `params_updated` | | Module parameters updated |
-| `lease_custom_domain_set` | lease_uuid, tenant, provider_uuid, service_name, custom_domain, set_by | `LeaseItem.custom_domain` set or changed (v2.1.0+; `provider_uuid` added v2.1.1+) |
-| `lease_custom_domain_cleared` | lease_uuid, tenant, provider_uuid, service_name, custom_domain (previous value), set_by | `LeaseItem.custom_domain` cleared (v2.1.0+; `provider_uuid` added v2.1.1+) |
+| `lease_custom_domain_set` | lease_uuid, tenant, provider_uuid, service_name, custom_domain, set_by | `LeaseItem.custom_domain` set or changed (v2.1.0+; `provider_uuid` added v2.2.0+) |
+| `lease_custom_domain_cleared` | lease_uuid, tenant, provider_uuid, service_name, custom_domain (previous value), set_by | `LeaseItem.custom_domain` cleared (v2.1.0+; `provider_uuid` added v2.2.0+) |
 
 **Custom-domain `set_by` attribute:** records the role under which the call was authorised. One of `tenant`, `authority`, `allowed`. No event is emitted for an idempotent re-set or a clear of an already-empty domain.
 


### PR DESCRIPTION
## Summary

Prepares the **v2.2.0** release. This is a **minor** bump for the `provider_uuid` custom-domain event attributes added in #155 — a backward-compatible `feat`, so it takes the feature digit rather than a patch.

## Changes

- **`Makefile`**: `VERSION v2.1.1 → v2.2.0`. This drives `app.Version()`, which in turn names the on-chain upgrade registered via `app/upgrades/next` (a generic noop handler that just runs module migrations — no state migration needed for an event-attribute addition).
- **`interchaintest/chain_upgrade_test.go`**: upgrade test now goes from the released **v2.1.1 → v2.2.0** (`baseChain.Version 2.1.0 → 2.1.1`, `upgradeName v2.1.1 → v2.2.0`).
- **`docs/FRONTEND.md`** & **`x/billing/docs/API.md`**: correct the `provider_uuid` availability label from `v2.1.1+` to `v2.2.0+`. v2.1.1 was tagged/released *before* #155 landed, so the feature is not in v2.1.1.

## Why minor, not patch

`#155` is a `feat:` (new, backward-compatible consumer functionality — a new event attribute, nothing removed/renamed). By conventional-commits → semver and this repo's own pattern (features → middle digit; deps/docs/fixes → patch digit), this warrants v2.2.0.

Not consensus/state-machine-breaking: CometBFT excludes events from the results hash, so emitting an extra attribute doesn't change the AppHash and requires no migration.

## Verification

- `go build ./...` (root module) ✅
- `go vet ./...` (interchaintest module) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)