### PR TITLE
chore: prepare v2.2.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DOCKER := $(shell which docker)
 LEDGER_ENABLED ?= true
 BINDIR ?= $(GOPATH)/bin
 BUILD_DIR = ./build
-VERSION ?= v2.2.0
+VERSION ?= v2.2.1
 GO ?= go
 GOROOT := $(shell $(GO) env GOROOT)
 export GOROOT

--- a/interchaintest/chain_upgrade_test.go
+++ b/interchaintest/chain_upgrade_test.go
@@ -30,7 +30,7 @@ var (
 	// baseChain is the current version of the chain that will be upgraded from
 	baseChain = ibc.DockerImage{
 		Repository: "ghcr.io/manifest-network/manifest-ledger",
-		Version:    "2.1.1",
+		Version:    "2.2.0",
 		UIDGID:     "1025:1025",
 	}
 
@@ -126,7 +126,7 @@ func TestBasicManifestUpgrade(t *testing.T) {
 	haltHeight := height + haltHeightDelta
 
 	// The upgrade name must match app.Version() in the new binary
-	upgradeName := "v2.2.0"
+	upgradeName := "v2.2.1"
 
 	t.Logf("Upgrade name: %s", upgradeName)
 	t.Logf("Current height: %d, halt height: %d", height, haltHeight)


### PR DESCRIPTION
## Summary

Prepares the **v2.2.1** release on the v2.2.x line.

- `Makefile`: `VERSION` → `v2.2.1`
- `interchaintest/chain_upgrade_test.go`: upgrade path is now `2.2.0` → `v2.2.1` (`baseChain.Version` `2.1.1`→`2.2.0`, `upgradeName` `v2.2.0`→`v2.2.1`)

## Context

v2.2.1 ships the ENG-288 EndBlocker validator-update dedup (forward-ported in #159) on the v2.2.x line — closing the duplicate-validator-update halt that hit mainnet on the v2.1.x line (fixed there in v2.1.3 / v2.1.4). No other app changes vs v2.2.0; this is a version/prep bump.

Tagging `v2.2.1` afterward also returns docker `:latest` and the GitHub "Latest" badge to the v2.2.x line — v2.1.4 had advanced "Latest" within the v2.1.x line during the incident response — since v2.2.1 is the highest semver tag.

## Release steps after merge

1. Tag `v2.2.1` on the merge commit → goreleaser (amd64 binary + GitHub release) + multi-arch docker images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
