### PR TITLE
refactor(pagination): store-level seek for index cursors, deletion-tolerant (ENG-477)

### DIFF
--- a/pkg/pagination/pagination.go
+++ b/pkg/pagination/pagination.go
@@ -15,10 +15,12 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/query"
 )
 
-// MatchExactWithOrder is like indexes.Multi.MatchExact but applies descending
-// iteration order when pageReq.Reverse is true.
-// It only controls iteration direction; limit, offset, and key-based cursor
-// pagination are handled by PaginateStringIndex (or similar) downstream.
+// MatchExactWithOrder builds an index iterator for refKey. It applies descending
+// order when pageReq.Reverse is set, and — when pageReq.Key is present — seeks the
+// iterator to the resume cursor with a store-level bound. That seek is O(log n)
+// and, unlike a front-scan, tolerant of the cursor row having been deleted between
+// page calls (it resumes from the nearest surviving key). limit, offset, and
+// count_total remain the responsibility of PaginateStringIndex downstream.
 func MatchExactWithOrder[RK, V any](
 	ctx context.Context,
 	idx *indexes.Multi[RK, string, V],
@@ -26,8 +28,25 @@ func MatchExactWithOrder[RK, V any](
 	pageReq *query.PageRequest,
 ) (indexes.MultiIterator[RK, string], error) {
 	rng := collections.NewPrefixedPairRange[RK, string](refKey)
-	if pageReq != nil && pageReq.Reverse {
-		rng = rng.Descending()
+	if pageReq != nil {
+		// Resume by seeking, inclusively, to the cursor key. collections.PairRange's
+		// Start* always binds the byte-order LOWER bound regardless of Descending(),
+		// so reverse resume must bound the UPPER end (EndInclusive, which uses
+		// RangeKeyNext) to land inclusively on the cursor and iterate strictly
+		// downward from it. Inclusive bounds (never Exclusive) preserve the
+		// first-unread + inclusive-resume next_key contract PaginateStringIndex
+		// produces, byte-for-byte.
+		if len(pageReq.Key) > 0 {
+			cursor := string(pageReq.Key)
+			if pageReq.Reverse {
+				rng = rng.EndInclusive(cursor)
+			} else {
+				rng = rng.StartInclusive(cursor)
+			}
+		}
+		if pageReq.Reverse {
+			rng = rng.Descending()
+		}
 	}
 	return idx.Iterate(ctx, rng)
 }
@@ -76,11 +95,10 @@ func PaginateStringIndex[V any](
 	var total uint64
 	var nextKey []byte
 
-	// Handle key-based pagination: skip items until we reach the start key
-	startKey := pageReq.Key
-	foundStart := len(startKey) == 0 // If no start key, we've already "found" it
-
-	// Handle offset-based pagination
+	// The iterator is already positioned at the resume point by MatchExactWithOrder
+	// (a store-level seek on pageReq.Key), so no front-scan is needed here. Offset
+	// applies only when no cursor key is set (matching prior behavior).
+	hasKey := len(pageReq.Key) > 0
 	offset := pageReq.Offset
 	var skipped uint64
 
@@ -88,15 +106,6 @@ func PaginateStringIndex[V any](
 		pk, err := iter.PrimaryKey()
 		if err != nil {
 			return nil, nil, err
-		}
-
-		// For key-based pagination, skip until we reach the start key
-		if !foundStart {
-			if string(startKey) == pk {
-				foundStart = true
-			} else {
-				continue
-			}
 		}
 
 		value, err := getter(ctx, pk)
@@ -123,7 +132,7 @@ func PaginateStringIndex[V any](
 		}
 
 		// Handle offset-based pagination (only applies if no key provided)
-		if len(startKey) == 0 && skipped < offset {
+		if !hasKey && skipped < offset {
 			skipped++
 			continue
 		}

--- a/pkg/pagination/pagination_test.go
+++ b/pkg/pagination/pagination_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cosmossdk.io/collections"
+	"cosmossdk.io/collections/colltest"
+	"cosmossdk.io/collections/indexes"
 
 	"github.com/cosmos/cosmos-sdk/types/query"
 )
@@ -102,11 +104,12 @@ func TestPaginateStringIndex_ExplicitLimit(t *testing.T) {
 }
 
 func TestPaginateStringIndex_KeyBasedCursor(t *testing.T) {
-	keys := []string{"a", "b", "c", "d", "e"}
-	data := map[string]string{"a": "1", "b": "2", "c": "3", "d": "4", "e": "5"}
-
-	// Start from key "c" (simulating second page with NextKey from previous call)
-	iter := newMockIterator(keys)
+	// MatchExactWithOrder now seeks the iterator to the cursor, so PaginateStringIndex
+	// receives an ALREADY-POSITIONED iterator (here, one that starts at "c"). The Key
+	// field only signals "a cursor is in play" (which disables offset); it no longer
+	// drives a front-scan inside this function.
+	iter := newMockIterator([]string{"c", "d", "e"})
+	data := map[string]string{"c": "3", "d": "4", "e": "5"}
 	values, pageResp, err := PaginateStringIndex(
 		context.Background(),
 		iter,
@@ -122,11 +125,10 @@ func TestPaginateStringIndex_KeyBasedCursor(t *testing.T) {
 }
 
 func TestPaginateStringIndex_KeyBasedCursorLastPage(t *testing.T) {
-	keys := []string{"a", "b", "c", "d", "e"}
-	data := map[string]string{"a": "1", "b": "2", "c": "3", "d": "4", "e": "5"}
-
-	// Start from key "d", limit 5 (more than remaining)
-	iter := newMockIterator(keys)
+	// Pre-positioned iterator starting at "d" (as MatchExactWithOrder would seek it),
+	// limit 5 (more than remaining) -> last page, empty NextKey.
+	iter := newMockIterator([]string{"d", "e"})
+	data := map[string]string{"d": "4", "e": "5"}
 	values, pageResp, err := PaginateStringIndex(
 		context.Background(),
 		iter,
@@ -317,12 +319,14 @@ func TestPaginateStringIndex_OffsetBeyondResults(t *testing.T) {
 	require.Empty(t, pageResp.NextKey)
 }
 
-func TestPaginateStringIndex_KeyNotFound(t *testing.T) {
-	// When the start key doesn't exist in the iterator, no results are returned
-	keys := []string{"a", "b", "c"}
+func TestPaginateStringIndex_KeyNotUsedForPositioning(t *testing.T) {
+	// PaginateStringIndex no longer front-scans for the cursor key — MatchExactWithOrder
+	// seeks the iterator instead (a store-level, deletion-tolerant seek). Here the Key
+	// does not match any yielded item; it is simply not used for positioning, so the
+	// pre-positioned iterator's items are all returned. (Deletion-tolerance itself is
+	// covered by the real-store keeper tests, since a mock iterator cannot seek.)
+	iter := newMockIterator([]string{"a", "b", "c"})
 	data := map[string]string{"a": "1", "b": "2", "c": "3"}
-
-	iter := newMockIterator(keys)
 	values, pageResp, err := PaginateStringIndex(
 		context.Background(),
 		iter,
@@ -332,7 +336,7 @@ func TestPaginateStringIndex_KeyNotFound(t *testing.T) {
 	)
 
 	require.NoError(t, err)
-	require.Empty(t, values, "no results when key is not found in iterator")
+	require.Equal(t, []string{"1", "2", "3"}, values, "Key is not a positioning input to PaginateStringIndex anymore")
 	require.Empty(t, pageResp.NextKey)
 }
 
@@ -412,4 +416,103 @@ func TestPaginateStringIndex_MultipleInconsistentEntries(t *testing.T) {
 	require.Len(t, values, 2)
 	require.Equal(t, []string{"1", "2"}, values)
 	require.Empty(t, pageResp.NextKey)
+}
+
+// --- Real in-memory collections index, to exercise MatchExactWithOrder's
+// --- store-level seek (which a mock iterator cannot express). ---
+
+type probeIndexes struct {
+	byGroup *indexes.Multi[int32, string, uint64]
+}
+
+func (i probeIndexes) IndexesList() []collections.Index[string, uint64] {
+	return []collections.Index[string, uint64]{i.byGroup}
+}
+
+func newProbeMap(t *testing.T) (*collections.IndexedMap[string, uint64, probeIndexes], context.Context) {
+	t.Helper()
+	sk, ctx := colltest.MockStore()
+	sb := collections.NewSchemaBuilder(sk)
+	im := collections.NewIndexedMap(
+		sb,
+		collections.NewPrefix(0), "probe",
+		collections.StringKey, collections.Uint64Value,
+		probeIndexes{
+			byGroup: indexes.NewMulti(
+				sb, collections.NewPrefix(1), "probe_by_group",
+				collections.Int32Key, collections.StringKey,
+				func(_ string, group uint64) (int32, error) { return int32(group), nil }, //nolint:gosec // test value fits int32
+			),
+		},
+	)
+	_, err := sb.Build()
+	require.NoError(t, err)
+	return im, ctx
+}
+
+// collectGroup pages the (group) index at pageReq via MatchExactWithOrder +
+// PaginateStringIndex, returning the primary keys collected on this page.
+func collectGroup(ctx context.Context, t *testing.T, im *collections.IndexedMap[string, uint64, probeIndexes], group int32, pageReq *query.PageRequest) ([]string, *query.PageResponse) {
+	t.Helper()
+	iter, err := MatchExactWithOrder(ctx, im.Indexes.byGroup, group, pageReq)
+	require.NoError(t, err)
+	keys, pageRes, err := PaginateStringIndex(ctx, iter,
+		func(_ context.Context, pk string) (string, error) { return pk, nil }, // value == primary key
+		pageReq, nil)
+	require.NoError(t, err)
+	return keys, pageRes
+}
+
+func TestMatchExactWithOrder_StoreSeek(t *testing.T) {
+	im, ctx := newProbeMap(t)
+	const g = int32(7)
+	for _, k := range []string{"k01", "k02", "k03", "k04", "k05"} {
+		require.NoError(t, im.Set(ctx, k, uint64(g)))
+	}
+	// A different group to prove the seek stays within the refKey prefix.
+	require.NoError(t, im.Set(ctx, "z99", uint64(9)))
+
+	t.Run("ascending resume is inclusive of the cursor", func(t *testing.T) {
+		keys, _ := collectGroup(ctx, t, im, g, &query.PageRequest{Key: []byte("k02"), Limit: 10})
+		require.Equal(t, []string{"k02", "k03", "k04", "k05"}, keys)
+	})
+
+	t.Run("reverse resume is inclusive of the cursor and descends", func(t *testing.T) {
+		keys, _ := collectGroup(ctx, t, im, g, &query.PageRequest{Key: []byte("k04"), Reverse: true, Limit: 10})
+		require.Equal(t, []string{"k04", "k03", "k02", "k01"}, keys)
+	})
+
+	t.Run("ascending is deletion-tolerant when the cursor row is gone", func(t *testing.T) {
+		require.NoError(t, im.Remove(ctx, "k02"))
+		keys, _ := collectGroup(ctx, t, im, g, &query.PageRequest{Key: []byte("k02"), Limit: 10})
+		require.Equal(t, []string{"k03", "k04", "k05"}, keys, "must resume from nearest surviving key, not return empty")
+		require.NoError(t, im.Set(ctx, "k02", uint64(g)))
+	})
+
+	t.Run("reverse is deletion-tolerant when the cursor row is gone", func(t *testing.T) {
+		require.NoError(t, im.Remove(ctx, "k04"))
+		keys, _ := collectGroup(ctx, t, im, g, &query.PageRequest{Key: []byte("k04"), Reverse: true, Limit: 10})
+		require.Equal(t, []string{"k03", "k02", "k01"}, keys)
+		require.NoError(t, im.Set(ctx, "k04", uint64(g)))
+	})
+
+	t.Run("seek stays within the refKey prefix", func(t *testing.T) {
+		keys, pageRes := collectGroup(ctx, t, im, g, &query.PageRequest{Key: []byte("k05"), Limit: 10})
+		require.Equal(t, []string{"k05"}, keys) // does not cross into group 9's z99
+		require.Empty(t, pageRes.NextKey)
+	})
+}
+
+func TestMatchExactWithOrder_PrefixCollisionReverse(t *testing.T) {
+	// Reverse resume from a cursor that is a byte-prefix of another key in the same
+	// group must NOT include the longer key. This pins EndInclusive's RangeKeyNext
+	// (tight, append-0x00) upper bound; a looser PrefixEndBytes (increment-last-byte)
+	// bound would wrongly pull "abcd" into a reverse page resumed from "ab".
+	im, ctx := newProbeMap(t)
+	const g = int32(3)
+	require.NoError(t, im.Set(ctx, "ab", uint64(g)))
+	require.NoError(t, im.Set(ctx, "abcd", uint64(g)))
+
+	keys, _ := collectGroup(ctx, t, im, g, &query.PageRequest{Key: []byte("ab"), Reverse: true, Limit: 10})
+	require.Equal(t, []string{"ab"}, keys, "reverse from 'ab' must yield only 'ab', not 'abcd'")
 }

--- a/x/billing/keeper/querier.go
+++ b/x/billing/keeper/querier.go
@@ -426,10 +426,25 @@ func (q Querier) LeasesBySKU(ctx context.Context, req *types.QueryLeasesBySKUReq
 		return nil, status.Error(codes.InvalidArgument, "sku_uuid cannot be empty")
 	}
 
-	// Use the SKU index to iterate only over leases containing this SKU
+	// Use the SKU index to iterate only over leases containing this SKU.
 	rng := collections.NewPrefixedPairRange[string, string](req.SkuUuid)
-	if req.Pagination != nil && req.Pagination.Reverse {
-		rng = rng.Descending()
+	if req.Pagination != nil {
+		// Resume by a store-level seek on the cursor (deletion-tolerant, O(log n)),
+		// mirroring pkg/pagination.MatchExactWithOrder. collections.PairRange's Start*
+		// binds the byte-order lower bound regardless of Descending(), so reverse
+		// resume must bound the upper end (EndInclusive) to land inclusively on the
+		// cursor and iterate downward. Inclusive bounds keep next_key wire-compatible.
+		if len(req.Pagination.Key) > 0 {
+			cursor := string(req.Pagination.Key)
+			if req.Pagination.Reverse {
+				rng = rng.EndInclusive(cursor)
+			} else {
+				rng = rng.StartInclusive(cursor)
+			}
+		}
+		if req.Pagination.Reverse {
+			rng = rng.Descending()
+		}
 	}
 	iter, err := q.k.LeaseBySKUIndex.Iterate(ctx, rng)
 	if err != nil {
@@ -607,8 +622,9 @@ func paginateSKUIndex(
 	var skipped uint64
 	var nextKey []byte
 
-	// For key-based pagination, skip until we reach the start key
-	foundStart := len(startKey) == 0
+	// The iterator is already positioned at the resume point by LeasesBySKU's
+	// store-level seek on pageReq.Key, so no front-scan is needed here.
+	hasKey := len(startKey) > 0
 
 	for ; iter.Valid(); iter.Next() {
 		key, err := iter.Key()
@@ -616,15 +632,6 @@ func paginateSKUIndex(
 			return nil, nil, err
 		}
 		leaseUUID := key.K2()
-
-		// Key-based pagination: skip entries until we find the cursor key
-		if !foundStart {
-			if string(startKey) == leaseUUID {
-				foundStart = true
-			} else {
-				continue
-			}
-		}
 
 		lease, err := getLease(ctx, leaseUUID)
 		if err != nil {
@@ -645,7 +652,7 @@ func paginateSKUIndex(
 		}
 
 		// Handle offset-based pagination (only when no key provided)
-		if len(startKey) == 0 && skipped < offset {
+		if !hasKey && skipped < offset {
 			skipped++
 			continue
 		}

--- a/x/billing/keeper/querier_test.go
+++ b/x/billing/keeper/querier_test.go
@@ -1176,6 +1176,79 @@ func TestQueryProviderWithdrawable(t *testing.T) {
 	})
 }
 
+// TestLeasesByProvider_ActiveCursorSurvivesClosedBoundary is the read-side analogue
+// of TestMsgWithdraw_ProviderWideCursorSurvivesClosedBoundaryLease: it closes the
+// exact lease named by a page's next_key (removing it from the (provider, ACTIVE)
+// index) and asserts the next page still resumes from the surviving tail rather than
+// silently returning empty. Under the old scan-until-match cursor this test fails.
+func TestLeasesByProvider_ActiveCursorSurvivesClosedBoundary(t *testing.T) {
+	f := initFixture(t)
+	k := f.App.BillingKeeper
+	querier := keeper.NewQuerier(k)
+
+	tenant := f.TestAccs[0]
+	providerAddr := f.TestAccs[1]
+	provider := f.createTestProvider(t, providerAddr.String(), providerAddr.String())
+	sku := f.createTestSKU(t, provider.Uuid, 3600)
+
+	uuids := make([]string, 0, 5)
+	for i := 1; i <= 5; i++ {
+		u := fmt.Sprintf("01912345-6789-7abc-8def-%012d", i)
+		require.NoError(t, k.SetLease(f.Ctx, types.Lease{
+			Uuid:          u,
+			Tenant:        tenant.String(),
+			ProviderUuid:  provider.Uuid,
+			Items:         []types.LeaseItem{{SkuUuid: sku.Uuid, Quantity: 1, LockedPrice: sdk.NewCoin(testDenom, sdkmath.NewInt(1))}},
+			State:         types.LEASE_STATE_ACTIVE,
+			CreatedAt:     f.Ctx.BlockTime(),
+			LastSettledAt: f.Ctx.BlockTime(),
+		}))
+		uuids = append(uuids, u)
+	}
+
+	// Page 1 (limit 2): returns the two smallest; next_key points at the 3rd (still ACTIVE).
+	p1, err := querier.LeasesByProvider(f.Ctx, &types.QueryLeasesByProviderRequest{
+		ProviderUuid: provider.Uuid,
+		StateFilter:  types.LEASE_STATE_ACTIVE,
+		Pagination:   &query.PageRequest{Limit: 2},
+	})
+	require.NoError(t, err)
+	require.Len(t, p1.Leases, 2)
+	require.NotEmpty(t, p1.Pagination.NextKey)
+	boundary := string(p1.Pagination.NextKey)
+
+	// Close the boundary lease so it drops out of the (provider, ACTIVE) index.
+	lease, err := k.GetLease(f.Ctx, boundary)
+	require.NoError(t, err)
+	closedAt := f.Ctx.BlockTime()
+	lease.State = types.LEASE_STATE_CLOSED
+	lease.ClosedAt = &closedAt
+	require.NoError(t, k.SetLease(f.Ctx, lease))
+
+	// Resume from the now-closed cursor: must reach the surviving tail, not return empty.
+	seen := map[string]bool{}
+	key := p1.Pagination.NextKey
+	for i := 0; i < 10; i++ {
+		p, err := querier.LeasesByProvider(f.Ctx, &types.QueryLeasesByProviderRequest{
+			ProviderUuid: provider.Uuid,
+			StateFilter:  types.LEASE_STATE_ACTIVE,
+			Pagination:   &query.PageRequest{Limit: 2, Key: key},
+		})
+		require.NoError(t, err)
+		for _, l := range p.Leases {
+			seen[l.Uuid] = true
+		}
+		if len(p.Pagination.NextKey) == 0 {
+			break
+		}
+		key = p.Pagination.NextKey
+	}
+
+	require.True(t, seen[uuids[3]], "tail lease must be reached after the boundary lease was closed")
+	require.True(t, seen[uuids[4]], "tail lease must be reached after the boundary lease was closed")
+	require.False(t, seen[boundary], "the closed boundary lease is no longer ACTIVE")
+}
+
 func TestQueryCreditAccounts(t *testing.T) {
 	f := initFixture(t)
 

--- a/x/sku/keeper/querier_test.go
+++ b/x/sku/keeper/querier_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"fmt"
 	"slices"
 	"testing"
 
@@ -758,6 +759,136 @@ func TestQuerierProviderByAddressReverse(t *testing.T) {
 	for i := range respFwd.Providers {
 		require.Equal(t, respFwd.Providers[i].Uuid, respRev.Providers[len(respRev.Providers)-1-i].Uuid)
 	}
+}
+
+// TestProviderByAddress_ActiveOnlyCursor exercises the one helper caller that
+// passes a non-nil filter (ActiveOnly) together with a key cursor, ascending and
+// reverse. It asserts the filter never leaks inactive providers and that the
+// cursor threads correctly across pages of filter-passing results.
+func TestProviderByAddress_ActiveOnlyCursor(t *testing.T) {
+	f := initFixture(t)
+	k := f.App.SKUKeeper
+	q := keeper.NewQuerier(k)
+
+	addr := f.TestAccs[0]
+	payoutAddr := f.TestAccs[2]
+
+	// 5 providers at one address, alternating active so the filter must skip.
+	active := []bool{true, false, true, false, true}
+	var wantActive []string
+	for i := 1; i <= 5; i++ {
+		uuid := fmt.Sprintf("01912345-6789-7abc-8def-0123456789a%d", i)
+		require.NoError(t, k.SetProvider(f.Ctx, types.Provider{
+			Uuid:          uuid,
+			Address:       addr.String(),
+			PayoutAddress: payoutAddr.String(),
+			Active:        active[i-1],
+		}))
+		if active[i-1] {
+			wantActive = append(wantActive, uuid)
+		}
+	}
+
+	// Page through ActiveOnly at limit 1, threading next_key.
+	collect := func(reverse bool) []string {
+		var got []string
+		var key []byte
+		for pages := 0; pages < 20; pages++ {
+			resp, err := q.ProviderByAddress(f.Ctx, &types.QueryProviderByAddressRequest{
+				Address:    addr.String(),
+				ActiveOnly: true,
+				Pagination: &query.PageRequest{Limit: 1, Key: key, Reverse: reverse},
+			})
+			require.NoError(t, err)
+			require.LessOrEqual(t, len(resp.Providers), 1)
+			for _, p := range resp.Providers {
+				require.True(t, p.Active, "ActiveOnly must never return an inactive provider")
+				got = append(got, p.Uuid)
+			}
+			if len(resp.Pagination.NextKey) == 0 {
+				break
+			}
+			key = resp.Pagination.NextKey
+		}
+		return got
+	}
+
+	require.Equal(t, wantActive, collect(false), "ascending filtered cursor returns active providers in order")
+
+	wantRev := slices.Clone(wantActive)
+	slices.Reverse(wantRev)
+	require.Equal(t, wantRev, collect(true), "reverse filtered cursor returns active providers in reverse order")
+}
+
+// TestSKUsByProvider_ActiveCursorSurvivesDeactivatedBoundary is the sku-module
+// deletion-tolerance regression: it deactivates the exact SKU named by a page's
+// next_key (removing it from the (provider, active) index) and asserts the next
+// page still resumes from the surviving tail rather than returning empty. Under
+// the old scan-until-match cursor this test fails.
+func TestSKUsByProvider_ActiveCursorSurvivesDeactivatedBoundary(t *testing.T) {
+	f := initFixture(t)
+	k := f.App.SKUKeeper
+	q := keeper.NewQuerier(k)
+
+	require.NoError(t, k.SetProvider(f.Ctx, types.Provider{
+		Uuid:          testProvider1UUID,
+		Address:       f.TestAccs[0].String(),
+		PayoutAddress: f.TestAccs[1].String(),
+		Active:        true,
+	}))
+
+	basePrice := sdk.NewCoin("umfx", sdkmath.NewInt(100))
+	uuids := make([]string, 0, 5)
+	for i := 1; i <= 5; i++ {
+		u := fmt.Sprintf("01912345-6789-7abc-8def-0123456789c%d", i)
+		require.NoError(t, k.SetSKU(f.Ctx, types.SKU{
+			Uuid:         u,
+			ProviderUuid: testProvider1UUID,
+			Name:         fmt.Sprintf("SKU %d", i),
+			Unit:         types.Unit_UNIT_PER_HOUR,
+			BasePrice:    basePrice,
+			Active:       true,
+		}))
+		uuids = append(uuids, u)
+	}
+
+	page1, err := q.SKUsByProvider(f.Ctx, &types.QuerySKUsByProviderRequest{
+		ProviderUuid: testProvider1UUID,
+		ActiveOnly:   true,
+		Pagination:   &query.PageRequest{Limit: 2},
+	})
+	require.NoError(t, err)
+	require.Len(t, page1.Skus, 2)
+	require.NotEmpty(t, page1.Pagination.NextKey)
+	boundary := string(page1.Pagination.NextKey)
+
+	// Deactivate the boundary SKU so it drops out of the (provider, active) index.
+	sku, err := k.GetSKU(f.Ctx, boundary)
+	require.NoError(t, err)
+	sku.Active = false
+	require.NoError(t, k.SetSKU(f.Ctx, sku))
+
+	seen := map[string]bool{}
+	key := page1.Pagination.NextKey
+	for i := 0; i < 10; i++ {
+		p, err := q.SKUsByProvider(f.Ctx, &types.QuerySKUsByProviderRequest{
+			ProviderUuid: testProvider1UUID,
+			ActiveOnly:   true,
+			Pagination:   &query.PageRequest{Limit: 2, Key: key},
+		})
+		require.NoError(t, err)
+		for _, s := range p.Skus {
+			seen[s.Uuid] = true
+		}
+		if len(p.Pagination.NextKey) == 0 {
+			break
+		}
+		key = p.Pagination.NextKey
+	}
+
+	require.True(t, seen[uuids[3]], "tail SKU must be reached after the boundary SKU was deactivated")
+	require.True(t, seen[uuids[4]], "tail SKU must be reached after the boundary SKU was deactivated")
+	require.False(t, seen[boundary], "the deactivated boundary SKU is no longer active")
 }
 
 // TestQueryErrorCasesComprehensive tests additional error cases across SKU queries


### PR DESCRIPTION
> **Stacked on #161 (ENG-475).** Base branch is `felix/eng-475-withdrawal-pagination`, so this PR shows only the ENG-477 diff. Merge/rebase after #161.

## Summary
`pkg/pagination.PaginateStringIndex` (used by every index-based query in `x/billing` and `x/sku`) resumed a key-based page by **scanning the index from the front** until it matched the cursor primary key. That is O(position) per page and — worse — **silently truncates**: if the cursor row leaves the index between page calls (e.g. a lease/provider changes state), the scan never matches and returns an **empty page with empty `next_key`**, indistinguishable from "done". Same silent-under-collection class as ENG-475, on the read side.

This migrates the cursor to a **store-level seek** (the idiomatic SDK resume, per `getCollIter`/`IterateRaw`), moving cursor handling up into `MatchExactWithOrder`:
- ascending resume: `rng.StartInclusive(cursor)`
- reverse resume: `rng.EndInclusive(cursor).Descending()`

`collections.PairRange` `Start*` always binds the byte-order **lower** bound regardless of `.Descending()`, so reverse resume must bound the **upper** end (`EndInclusive`, via `RangeKeyNext`). Inclusive bounds keep the existing *first-unread + inclusive-resume* `next_key` **byte-for-byte compatible** (no client change).

All **11 helper call sites** inherit the fix with zero caller edits; the hand-rolled `paginateSKUIndex` duplicate (`LeasesBySKU`) gets the same treatment.

## Behavior change (non-consensus, query-only)
A stale/garbage cursor now **resumes from the nearest surviving key** instead of returning an empty page — the deletion-tolerance we want. `TestPaginateStringIndex_KeyNotFound` pinned the old empty-page behavior and was rewritten.

## Tests
- Rewrote the mock cursor tests to reflect that `PaginateStringIndex` now receives a pre-positioned iterator.
- **Real-store `MatchExactWithOrder` probe** (`colltest`): ascending/reverse inclusive resume, deletion-tolerance both directions, prefix-scoping, and a **prefix-collision reverse** test pinning `RangeKeyNext` tightness (guards against a future `collections` bump).
- Read-side **deletion-tolerance regression** test (`TestLeasesByProvider_ActiveCursorSurvivesClosedBoundary`) — the analogue of ENG-475's `...CursorSurvivesClosedBoundaryLease`; fails under the old scan-until-match.

## Verification
- `go build ./...`, `go vet`, `golangci-lint` (v1.63.4) all clean.
- `pkg/pagination`, `x/billing/keeper`, `x/sku/keeper` suites green — including the load-bearing reverse+cursor guards (`LeasesByTenant`, `SKUsByProvider`).

Resolves ENG-477.

🤖 Generated with [Claude Code](https://claude.ai/code)