### PR TITLE
chore: prepare v2.3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DOCKER := $(shell which docker)
 LEDGER_ENABLED ?= true
 BINDIR ?= $(GOPATH)/bin
 BUILD_DIR = ./build
-VERSION ?= v2.2.1
+VERSION ?= v2.3.0
 GO ?= go
 GOROOT := $(shell $(GO) env GOROOT)
 export GOROOT

--- a/interchaintest/chain_upgrade_test.go
+++ b/interchaintest/chain_upgrade_test.go
@@ -30,7 +30,7 @@ var (
 	// baseChain is the current version of the chain that will be upgraded from
 	baseChain = ibc.DockerImage{
 		Repository: "ghcr.io/manifest-network/manifest-ledger",
-		Version:    "2.2.0",
+		Version:    "2.2.1",
 		UIDGID:     "1025:1025",
 	}
 
@@ -126,7 +126,7 @@ func TestBasicManifestUpgrade(t *testing.T) {
 	haltHeight := height + haltHeightDelta
 
 	// The upgrade name must match app.Version() in the new binary
-	upgradeName := "v2.2.1"
+	upgradeName := "v2.3.0"
 
 	t.Logf("Upgrade name: %s", upgradeName)
 	t.Logf("Current height: %d, halt height: %d", height, haltHeight)


### PR DESCRIPTION
## Release prep for v2.3.0

Bumps `VERSION` and the chain-upgrade e2e test in preparation for tagging **v2.3.0**.

### Changes since v2.2.1
- `feat(billing): paginate provider-wide withdrawal with an opaque cursor (ENG-475)` (#161)
- `chore: update x/net` (#163)
- `chore: update x/crypto` (#164)

Version convention: one `feat` → minor bump (`v2.2.1` → `v2.3.0`).

### This PR
- `Makefile`: `VERSION ?= v2.3.0` — drives `app.Version()`, so the on-chain upgrade name auto-tracks to `v2.3.0`.
- `interchaintest/chain_upgrade_test.go`: upgrade **from** the released `2.2.1` image, upgrade name `v2.3.0`.

### Upgrade notes
- ⚠️ **Consensus-breaking**: ENG-475 adds `MsgWithdraw.key` (field 5) / `MsgWithdrawResponse.next_key` and renumbers the `QueryProviderWithdrawable` proto. Pre-upgrade binaries reject txs carrying the new critical (<1024) field, so this **must ship as a coordinated on-chain upgrade** at a switch height — not a rolling binary swap.
- No state migration: pagination cursors are computed on-touch, not stored. The upgrade rides the existing noop `next` handler (`RunMigrations` only); no new handler code or `StoreUpgrades` needed.

After this merges to `main`, the release is cut by tagging the merge commit `v2.3.0` and pushing the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)