### PR TITLE
fix(billing): derive credit-estimate lease caps from params (ENG-527)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -74,6 +74,7 @@ jobs:
           - "ictest-chain-upgrade"
           - "ictest-sku"
           - "ictest-billing"
+          - "ictest-billing-extra"
           - "ictest-billing-upgrade"
       fail-fast: false
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -69,6 +69,7 @@ jobs:
           - "ictest-tokenfactory"
           - "ictest-manifest"
           - "ictest-group-poa"
+          - "ictest-group"
           - "ictest-cosmwasm"
           - "ictest-chain-upgrade"
           - "ictest-sku"

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,12 @@ ictest-sku:
 	cd interchaintest && go test -race -v -run TestSKU . -count=1
 
 ictest-billing:
-	cd interchaintest && go test -race -v -timeout 45m -run "^TestBilling(Lease|Credit|CreditEstimateOvershoot|CustomDomain|Advanced|State|Reservation)$$" . -count=1
+	cd interchaintest && go test -race -v -timeout 45m -run "^TestBilling(Lease|Credit|Advanced|State|Reservation)$$" . -count=1
+
+# Extra billing e2e tests kept out of the main ictest-billing batch so it stays under the 45m
+# timeout. Runs as its own parallel CI job.
+ictest-billing-extra:
+	cd interchaintest && go test -race -v -timeout 45m -run "^TestBilling(CreditEstimateOvershoot|CustomDomain)$$" . -count=1
 
 ictest-billing-lease:
 	cd interchaintest && go test -race -v -timeout 45m -run TestBillingLease . -count=1
@@ -162,7 +167,7 @@ ictest-billing-upgrade:
 ictest-billing-reservation:
 	cd interchaintest && go test -race -v -timeout 45m -run TestBillingReservation . -count=1
 
-.PHONY: ictest-ibc ictest-tokenfactory ictest-manifest ictest-poa ictest-poa-unjail-dup ictest-poa-unjail-dup-bug ictest-group-poa ictest-cosmwasm ictest-chain-upgrade ictest-group ictest-sku ictest-billing ictest-billing-lease ictest-billing-credit ictest-billing-advanced ictest-billing-state ictest-billing-upgrade ictest-billing-reservation
+.PHONY: ictest-ibc ictest-tokenfactory ictest-manifest ictest-poa ictest-poa-unjail-dup ictest-poa-unjail-dup-bug ictest-group-poa ictest-cosmwasm ictest-chain-upgrade ictest-group ictest-sku ictest-billing ictest-billing-extra ictest-billing-lease ictest-billing-credit ictest-billing-advanced ictest-billing-state ictest-billing-upgrade ictest-billing-reservation
 
 ###############################################################################
 ###                                Build Image                              ###

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ ictest-sku:
 	cd interchaintest && go test -race -v -run TestSKU . -count=1
 
 ictest-billing:
-	cd interchaintest && go test -race -v -timeout 45m -run "^TestBilling(Lease|Credit|Advanced|State|Reservation)$$" . -count=1
+	cd interchaintest && go test -race -v -timeout 45m -run "^TestBilling(Lease|Credit|CreditEstimateOvershoot|CustomDomain|Advanced|State|Reservation)$$" . -count=1
 
 ictest-billing-lease:
 	cd interchaintest && go test -race -v -timeout 45m -run TestBillingLease . -count=1

--- a/interchaintest/billing_credit_test.go
+++ b/interchaintest/billing_credit_test.go
@@ -444,3 +444,95 @@ func testWithdrawableQueriesIndependent(t *testing.T, ctx context.Context, tc *b
 		t.Logf("Total withdrawable for provider: %s (leases: %d)", res.Amounts, res.LeaseCount)
 	})
 }
+
+// TestBillingCreditEstimateOvershoot is an end-to-end test for ENG-527. It drives a tenant into
+// the pending->active acknowledge overshoot — active lease count exceeding max_leases_per_tenant,
+// reachable because AcknowledgeLease moves pending->active without re-gating the active limit — and
+// verifies that CreditEstimate sums the burn rate over ALL active leases rather than truncating at
+// max_leases_per_tenant. The query iteration cap is derived from
+// max_leases_per_tenant + max_pending_leases_per_tenant (the maximum reachable active count).
+func TestBillingCreditEstimateOvershoot(t *testing.T) {
+	ctx, tc, cleanup := setupBillingTest(t, "billing-estimate-overshoot")
+	t.Cleanup(cleanup)
+
+	// Lower the lease limits so the overshoot is reachable with a handful of txs:
+	// max_leases_per_tenant=2, max_pending_leases_per_tenant=2 => reachable active =
+	// (2-1)+2 = 3, strictly greater than max_leases_per_tenant.
+	current, err := helpers.BillingQueryParams(ctx, tc.chain)
+	require.NoError(t, err)
+	paramRes, err := helpers.BillingUpdateParams(ctx, tc.chain, tc.authority,
+		2, // max_leases_per_tenant
+		current.Params.MaxItemsPerLease,
+		current.Params.MinLeaseDuration,
+		2, // max_pending_leases_per_tenant
+		current.Params.PendingTimeout,
+		nil, // preserve allowed_list
+	)
+	require.NoError(t, err)
+	paramTx, err := tc.chain.GetTransaction(paramRes.TxHash)
+	require.NoError(t, err)
+	require.Equal(t, uint32(0), paramTx.Code, "params update should succeed: %s", paramTx.RawLog)
+	require.NoError(t, testutil.WaitForBlocks(ctx, 2, tc.chain))
+
+	// Fresh tenant with a well-funded credit account.
+	users := interchaintest.GetAndFundTestUsers(t, ctx, "overshoot-tenant", DefaultGenesisAmt, tc.chain)
+	tenant := users[0]
+	err = tc.chain.SendFunds(ctx, tc.authority.KeyName(), ibc.WalletAmount{
+		Address: tenant.FormattedAddress(),
+		Denom:   tc.pwrDenom,
+		Amount:  sdkmath.NewInt(100_000_000),
+	})
+	require.NoError(t, err)
+	fundRes, err := helpers.BillingFundCredit(ctx, tc.chain, tenant, tenant.FormattedAddress(),
+		fmt.Sprintf("100000000%s", tc.pwrDenom))
+	require.NoError(t, err)
+	fundTx, err := tc.chain.GetTransaction(fundRes.TxHash)
+	require.NoError(t, err)
+	require.Equal(t, uint32(0), fundTx.Code, "fund credit should succeed: %s", fundTx.RawLog)
+	require.NoError(t, testutil.WaitForBlocks(ctx, 2, tc.chain))
+
+	items := []string{fmt.Sprintf("%s:1", tc.skuUUID)}
+
+	// createLease creates a single PENDING lease and returns its UUID.
+	createLease := func() string {
+		res, err := helpers.BillingCreateLease(ctx, tc.chain, tenant, items)
+		require.NoError(t, err)
+		require.NoError(t, testutil.WaitForBlocks(ctx, 2, tc.chain))
+		uuid, err := helpers.GetLeaseIDFromTxHash(ctx, tc.chain, res.TxHash)
+		require.NoError(t, err)
+		require.NotEmpty(t, uuid)
+		return uuid
+	}
+	ack := func(uuids ...string) {
+		res, err := helpers.BillingAcknowledgeLeases(ctx, tc.chain, tc.providerWallet, uuids)
+		require.NoError(t, err)
+		ackTx, err := tc.chain.GetTransaction(res.TxHash)
+		require.NoError(t, err)
+		require.Equal(t, uint32(0), ackTx.Code, "acknowledge should succeed: %s", ackTx.RawLog)
+		require.NoError(t, testutil.WaitForBlocks(ctx, 2, tc.chain))
+	}
+
+	// Reach active = max_leases_per_tenant-1 = 1, then overshoot to 3.
+	l1 := createLease() // pending 1 (active 0 < 2)
+	ack(l1)             // active 1
+
+	// Baseline burn rate for a single active lease.
+	baseline, err := helpers.BillingQueryCreditEstimate(ctx, tc.chain, tenant.FormattedAddress())
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), baseline.ActiveLeaseCount)
+	baseAmt := baseline.TotalRatePerSecond.AmountOf(tc.pwrDenom)
+	require.True(t, baseAmt.IsPositive(), "single-lease baseline rate must be positive in the funded denom")
+
+	l2 := createLease() // pending 1 (active 1 < 2)
+	l3 := createLease() // pending 2 (active 1 < 2, pending 2 <= 2)
+	ack(l2, l3)         // active 3 -> overshoot past max_leases_per_tenant (2)
+
+	res, err := helpers.BillingQueryCreditEstimate(ctx, tc.chain, tenant.FormattedAddress())
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), res.ActiveLeaseCount,
+		"CreditEstimate must count all active leases in the overshoot state")
+	require.Equal(t, baseAmt.MulRaw(3), res.TotalRatePerSecond.AmountOf(tc.pwrDenom),
+		"burn rate must sum all 3 active leases (3x baseline), not truncate at max_leases_per_tenant")
+	t.Logf("Overshoot verified: active_leases=%d (max_leases_per_tenant=2), rate/sec=%s",
+		res.ActiveLeaseCount, res.TotalRatePerSecond)
+}

--- a/x/billing/README.md
+++ b/x/billing/README.md
@@ -242,7 +242,8 @@ These values are compile-time constants and cannot be changed via governance:
 | `CreditAccountAddressPrefix` | `billing/credit/` | Prefix used for deterministic credit address derivation |
 | `DefaultProviderWithdrawableQueryLimit` | 100 | Default limit for ProviderWithdrawable query |
 | `MaxProviderWithdrawableQueryLimit` | 1000 | Maximum limit for ProviderWithdrawable query |
-| `MaxCreditEstimateLeases` | 100 | Maximum active leases processed in CreditEstimate query |
+
+> **CreditEstimate / CreditAccount query iteration** is not a fixed constant — it tracks the lease params. The active-lease iteration is bounded by `max_leases_per_tenant + max_pending_leases_per_tenant` (the maximum *reachable* active count, since `AcknowledgeLease` moves pending→active without re-gating the active limit), and the pending-lease iteration by `max_pending_leases_per_tenant`. Each is clamped to the params' upper bounds (10,000 / 1,000) as a hard safety ceiling, so the caps never truncate a legal state yet stay bounded against DoS.
 
 ### Batch Operations
 

--- a/x/billing/README.md
+++ b/x/billing/README.md
@@ -243,7 +243,7 @@ These values are compile-time constants and cannot be changed via governance:
 | `DefaultProviderWithdrawableQueryLimit` | 100 | Default limit for ProviderWithdrawable query |
 | `MaxProviderWithdrawableQueryLimit` | 1000 | Maximum limit for ProviderWithdrawable query |
 
-> **CreditEstimate / CreditAccount query iteration** is not a fixed constant — it tracks the lease params. The active-lease iteration is bounded by `max_leases_per_tenant + max_pending_leases_per_tenant` (the maximum *reachable* active count, since `AcknowledgeLease` moves pending→active without re-gating the active limit), and the pending-lease iteration by `max_pending_leases_per_tenant`. Each is clamped to the params' upper bounds (10,000 / 1,000) as a hard safety ceiling, so the caps never truncate a legal state yet stay bounded against DoS.
+> **CreditEstimate / CreditAccount query iteration** is not a fixed constant — it tracks the lease params. The active-lease iteration is bounded by `max_leases_per_tenant + max_pending_leases_per_tenant`, a safe upper bound on the reachable active count: because `AcknowledgeLease` moves pending→active without re-gating the active limit, a tenant can reach `max_leases_per_tenant - 1 + max_pending_leases_per_tenant` active leases, and the cap adds a one-lease margin on top. The pending-lease iteration is bounded by `max_pending_leases_per_tenant`. Each is clamped to the params' upper bounds (10,000 / 1,000) as a hard safety ceiling, so the caps never truncate a legal state yet stay bounded against DoS.
 
 ### Batch Operations
 

--- a/x/billing/docs/API.md
+++ b/x/billing/docs/API.md
@@ -927,7 +927,7 @@ manifestd query billing credit-estimate manifest1abc...
 - With multi-denom support, the estimate returns the minimum duration across all denominations (the limiting factor)
 
 **Limitations:**
-- **Maximum 100 leases processed**: If a tenant has more than 100 active leases, only the first 100 are included in the calculation. The `active_lease_count` will show the actual count, but rates may be underestimated for tenants with >100 leases.
+- **Bounded lease iteration**: The active-lease iteration is bounded by `max_leases_per_tenant + max_pending_leases_per_tenant` — a safe upper bound on the reachable active-lease count, clamped to the params' upper bounds (10,000 / 1,000) as a hard DoS ceiling. This covers every legitimately-reachable state, so `total_rate_per_second` and `active_lease_count` reflect all of a tenant's active leases and are not truncated at a fixed 100.
 - **Does not account for pending withdrawals**: The estimate uses current balance, not accounting for any unsettled accrued amounts from existing leases.
 
 ---

--- a/x/billing/keeper/keeper.go
+++ b/x/billing/keeper/keeper.go
@@ -795,6 +795,21 @@ func (k *Keeper) getCreditBalancesForDenoms(ctx context.Context, tenant string, 
 	return coins, nil
 }
 
+// maxReachableActiveLeases returns an upper bound on the number of ACTIVE leases a single tenant
+// can hold. CreateLease gates on the active count (msg_server.go), but AcknowledgeLease moves
+// pending->active without re-checking that gate, so the active count can overshoot
+// max_leases_per_tenant by up to max_pending_leases_per_tenant (reaching
+// max_leases_per_tenant-1 + max_pending_leases_per_tenant). Query iterations over a tenant's
+// active leases must use this bound — not max_leases_per_tenant alone — or they truncate a
+// legitimately-reachable state. The sum is clamped to the params' upper bounds so it stays
+// bounded against DoS even for a maximally-large (but still valid) param configuration.
+func maxReachableActiveLeases(params types.Params) uint64 {
+	return min(
+		params.MaxLeasesPerTenant+params.MaxPendingLeasesPerTenant,
+		types.MaxLeasesPerTenantUpperBound+types.MaxPendingLeasesPerTenantUpperBound,
+	)
+}
+
 // getRelevantDenomsForTenant collects the unique denoms from a tenant's active and pending leases
 // plus any denoms in the reserved amounts. This avoids GetAllBalances which loads dust from spam.
 // Uses streaming iteration with a cap to avoid loading all leases into memory.
@@ -819,18 +834,34 @@ func (k *Keeper) getRelevantDenomsForTenant(ctx context.Context, tenant string, 
 		return nil, err
 	}
 
+	// Each state's iteration is bounded by its governing param (clamped to the param's upper
+	// bound as a hard safety ceiling): active leases by the maximum reachable active count
+	// (maxReachableActiveLeases, which accounts for the pending->active acknowledge overshoot),
+	// pending leases by max_pending_leases_per_tenant. This keeps the denom set complete for any
+	// legal state while remaining bounded against DoS.
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		return nil, err
+	}
+	activeCap := maxReachableActiveLeases(params)
+	pendingCap := min(params.MaxPendingLeasesPerTenant, types.MaxPendingLeasesPerTenantUpperBound)
+
 	// Include denoms from active and pending leases via streaming iteration.
-	// Cap to MaxCreditEstimateLeases per state to bound query cost.
 	for _, state := range []types.LeaseState{types.LEASE_STATE_ACTIVE, types.LEASE_STATE_PENDING} {
+		maxLeases := activeCap
+		if state == types.LEASE_STATE_PENDING {
+			maxLeases = pendingCap
+		}
+
 		key := collections.Join(tenantAddr, int32(state))
 		iter, err := k.Leases.Indexes.TenantState.MatchExact(ctx, key)
 		if err != nil {
 			return nil, err
 		}
 
-		var count int
+		var count uint64
 		for ; iter.Valid(); iter.Next() {
-			if count >= int(types.MaxCreditEstimateLeases) {
+			if count >= maxLeases {
 				break
 			}
 			count++

--- a/x/billing/keeper/keeper.go
+++ b/x/billing/keeper/keeper.go
@@ -795,15 +795,16 @@ func (k *Keeper) getCreditBalancesForDenoms(ctx context.Context, tenant string, 
 	return coins, nil
 }
 
-// maxReachableActiveLeases returns an upper bound on the number of ACTIVE leases a single tenant
-// can hold. CreateLease gates on the active count (msg_server.go), but AcknowledgeLease moves
-// pending->active without re-checking that gate, so the active count can overshoot
-// max_leases_per_tenant by up to max_pending_leases_per_tenant (reaching
-// max_leases_per_tenant-1 + max_pending_leases_per_tenant). Query iterations over a tenant's
-// active leases must use this bound — not max_leases_per_tenant alone — or they truncate a
-// legitimately-reachable state. The sum is clamped to the params' upper bounds so it stays
-// bounded against DoS even for a maximally-large (but still valid) param configuration.
-func maxReachableActiveLeases(params types.Params) uint64 {
+// activeLeaseIterationCap returns the upper bound to use when iterating a single tenant's ACTIVE
+// leases in queries. CreateLease gates on the active count (msg_server.go), but AcknowledgeLease
+// moves pending->active without re-checking that gate, so the active count can overshoot
+// max_leases_per_tenant: the tight reachable maximum through the handlers is
+// max_leases_per_tenant-1 + max_pending_leases_per_tenant. This deliberately returns
+// max_leases_per_tenant + max_pending_leases_per_tenant -- that tight maximum plus a one-lease
+// margin -- so the iteration never truncates a legitimately-reachable state even if the gating
+// logic later shifts by a lease. Callers must use this bound, not max_leases_per_tenant alone. The
+// sum is clamped to the params' upper bounds so it stays bounded against DoS for any valid config.
+func activeLeaseIterationCap(params types.Params) uint64 {
 	return min(
 		params.MaxLeasesPerTenant+params.MaxPendingLeasesPerTenant,
 		types.MaxLeasesPerTenantUpperBound+types.MaxPendingLeasesPerTenantUpperBound,
@@ -835,15 +836,15 @@ func (k *Keeper) getRelevantDenomsForTenant(ctx context.Context, tenant string, 
 	}
 
 	// Each state's iteration is bounded by its governing param (clamped to the param's upper
-	// bound as a hard safety ceiling): active leases by the maximum reachable active count
-	// (maxReachableActiveLeases, which accounts for the pending->active acknowledge overshoot),
-	// pending leases by max_pending_leases_per_tenant. This keeps the denom set complete for any
-	// legal state while remaining bounded against DoS.
+	// bound as a hard safety ceiling): active leases by the param-derived active-lease cap
+	// (activeLeaseIterationCap, which covers the pending->active acknowledge overshoot), pending
+	// leases by max_pending_leases_per_tenant. This keeps the denom set complete for any legal
+	// state while remaining bounded against DoS.
 	params, err := k.GetParams(ctx)
 	if err != nil {
 		return nil, err
 	}
-	activeCap := maxReachableActiveLeases(params)
+	activeCap := activeLeaseIterationCap(params)
 	pendingCap := min(params.MaxPendingLeasesPerTenant, types.MaxPendingLeasesPerTenantUpperBound)
 
 	// Include denoms from active and pending leases via streaming iteration.

--- a/x/billing/keeper/querier.go
+++ b/x/billing/keeper/querier.go
@@ -521,12 +521,13 @@ func (q Querier) CreditEstimate(ctx context.Context, req *types.QueryCreditEstim
 	defer iter.Close()
 
 	for ; iter.Valid(); iter.Next() {
-		activeLeaseCount++
-
-		// Bounded by the param-derived cap (see maxActiveLeases above).
-		if activeLeaseCount > maxActiveLeases {
+		// Bounded by the param-derived cap (see maxActiveLeases above). Check before the
+		// increment (mirroring getRelevantDenomsForTenant) so ActiveLeaseCount and the
+		// summed set never diverge if the cap is ever reached.
+		if activeLeaseCount >= maxActiveLeases {
 			break
 		}
+		activeLeaseCount++
 
 		leaseUUID, err := iter.PrimaryKey()
 		if err != nil {

--- a/x/billing/keeper/querier.go
+++ b/x/billing/keeper/querier.go
@@ -495,15 +495,14 @@ func (q Querier) CreditEstimate(ctx context.Context, req *types.QueryCreditEstim
 		return nil, status.Error(codes.NotFound, err.Error())
 	}
 
-	// Bound the active-lease iteration by the maximum reachable active count (param-derived,
-	// clamped to the params' upper bounds as a hard safety ceiling). This keeps the burn-rate
-	// estimate correct for any legal state while remaining bounded against DoS on tenants with
-	// many leases.
+	// Bound the active-lease iteration by the param-derived active-lease cap (clamped to the
+	// params' upper bounds as a hard safety ceiling). This keeps the burn-rate estimate correct
+	// for any legal state while remaining bounded against DoS on tenants with many leases.
 	params, err := q.k.GetParams(ctx)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-	maxActiveLeases := maxReachableActiveLeases(params)
+	maxActiveLeases := activeLeaseIterationCap(params)
 
 	// Calculate total rate per second across all active leases.
 	// Also collect relevant denoms for per-denom balance queries (DoS mitigation).

--- a/x/billing/keeper/querier.go
+++ b/x/billing/keeper/querier.go
@@ -495,9 +495,18 @@ func (q Querier) CreditEstimate(ctx context.Context, req *types.QueryCreditEstim
 		return nil, status.Error(codes.NotFound, err.Error())
 	}
 
+	// Bound the active-lease iteration by the maximum reachable active count (param-derived,
+	// clamped to the params' upper bounds as a hard safety ceiling). This keeps the burn-rate
+	// estimate correct for any legal state while remaining bounded against DoS on tenants with
+	// many leases.
+	params, err := q.k.GetParams(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	maxActiveLeases := maxReachableActiveLeases(params)
+
 	// Calculate total rate per second across all active leases.
 	// Also collect relevant denoms for per-denom balance queries (DoS mitigation).
-	// Limited to MaxCreditEstimateLeases to prevent DoS on tenants with many leases.
 	totalRatePerSecond := sdk.NewCoins()
 	var activeLeaseCount uint64
 	denomSet := make(map[string]struct{})
@@ -514,8 +523,8 @@ func (q Querier) CreditEstimate(ctx context.Context, req *types.QueryCreditEstim
 	for ; iter.Valid(); iter.Next() {
 		activeLeaseCount++
 
-		// Limit active leases processed (should match max_leases_per_tenant param)
-		if activeLeaseCount > types.MaxCreditEstimateLeases {
+		// Bounded by the param-derived cap (see maxActiveLeases above).
+		if activeLeaseCount > maxActiveLeases {
 			break
 		}
 

--- a/x/billing/keeper/querier_test.go
+++ b/x/billing/keeper/querier_test.go
@@ -1639,7 +1639,8 @@ func TestQueryCreditEstimate_ParamDerivedActiveCap(t *testing.T) {
 	f.fundAccount(t, creditAddr, sdk.NewCoins(sdk.NewCoin(testDenom, sdkmath.NewInt(1_000_000_000))))
 
 	// Create 150 active leases, each 1 unit/sec. The legacy code caps iteration at 100,
-	// under-summing the burn rate; the param-derived cap (200) sums all 150.
+	// under-summing the burn rate; the param-derived cap (max_leases_per_tenant +
+	// max_pending_leases_per_tenant = 210) sums all 150.
 	const numLeases = 150
 	for i := range numLeases {
 		require.NoError(t, k.SetLease(f.Ctx, types.Lease{
@@ -1670,8 +1671,9 @@ func TestQueryCreditEstimate_ParamDerivedActiveCap(t *testing.T) {
 
 // TestQueryCreditAccount_IncludesActiveDenomBeyondLegacyCap verifies that a denom used
 // only by an active lease past position #100 still appears in the CreditAccount balances.
-// getRelevantDenomsForTenant must cap the active iteration by max_leases_per_tenant, not
-// the legacy hardcoded 100, or the tail denom's balance is silently omitted.
+// getRelevantDenomsForTenant must cap the active iteration by the param-derived reachable
+// ceiling (max_leases_per_tenant + max_pending_leases_per_tenant), not the legacy hardcoded
+// 100, or the tail denom's balance is silently omitted.
 func TestQueryCreditAccount_IncludesActiveDenomBeyondLegacyCap(t *testing.T) {
 	f := initFixture(t)
 	k := f.App.BillingKeeper
@@ -1807,7 +1809,7 @@ func TestQueryCreditEstimate_ActiveCapBoundsIteration(t *testing.T) {
 	cases := []struct {
 		name       string
 		numLeases  int
-		expectRate int64
+		expectRate uint64
 	}{
 		{"below cap (overshoot band)", 7, 7},
 		{"exactly at cap", capLimit, capLimit},
@@ -1853,8 +1855,10 @@ func TestQueryCreditEstimate_ActiveCapBoundsIteration(t *testing.T) {
 
 			resp, err := querier.CreditEstimate(f.Ctx, &types.QueryCreditEstimateRequest{Tenant: tenant.String()})
 			require.NoError(t, err)
-			require.Equal(t, sdkmath.NewInt(tc.expectRate), resp.TotalRatePerSecond.AmountOf(testDenom),
+			require.Equal(t, sdkmath.NewIntFromUint64(tc.expectRate), resp.TotalRatePerSecond.AmountOf(testDenom),
 				"active-lease rate sum must equal min(numLeases, cap)")
+			require.Equal(t, tc.expectRate, resp.ActiveLeaseCount,
+				"ActiveLeaseCount must equal the number of leases summed (no off-by-one at the cap boundary)")
 		})
 	}
 }

--- a/x/billing/keeper/querier_test.go
+++ b/x/billing/keeper/querier_test.go
@@ -1612,6 +1612,378 @@ func TestQueryCreditEstimate(t *testing.T) {
 	})
 }
 
+// TestQueryCreditEstimate_ParamDerivedActiveCap verifies the CreditEstimate burn-rate
+// sum tracks the max_leases_per_tenant param instead of the legacy hardcoded cap of 100.
+// With the param raised to 200, a tenant with >100 active leases must have every lease's
+// rate summed; truncating at 100 underestimates burn (overestimates remaining runway).
+func TestQueryCreditEstimate_ParamDerivedActiveCap(t *testing.T) {
+	f := initFixture(t)
+	k := f.App.BillingKeeper
+	querier := keeper.NewQuerier(k)
+
+	tenant := f.TestAccs[0]
+
+	// Raise the active-lease param above the legacy hardcoded cap of 100.
+	params, err := k.GetParams(f.Ctx)
+	require.NoError(t, err)
+	params.MaxLeasesPerTenant = 200
+	require.NoError(t, k.SetParams(f.Ctx, params))
+
+	creditAddr := types.DeriveCreditAddress(tenant)
+	require.NoError(t, k.SetCreditAccount(f.Ctx, types.CreditAccount{
+		Tenant:        tenant.String(),
+		CreditAddress: creditAddr.String(),
+	}))
+
+	// Fund generously so the estimate is rate-bound, not balance-bound.
+	f.fundAccount(t, creditAddr, sdk.NewCoins(sdk.NewCoin(testDenom, sdkmath.NewInt(1_000_000_000))))
+
+	// Create 150 active leases, each 1 unit/sec. The legacy code caps iteration at 100,
+	// under-summing the burn rate; the param-derived cap (200) sums all 150.
+	const numLeases = 150
+	for i := range numLeases {
+		require.NoError(t, k.SetLease(f.Ctx, types.Lease{
+			Uuid:         fmt.Sprintf("01912345-6789-7abc-8def-active%06d", i),
+			Tenant:       tenant.String(),
+			ProviderUuid: testProviderUUID,
+			Items: []types.LeaseItem{
+				{
+					SkuUuid:     "01912345-6789-7abc-8def-sku000000001",
+					Quantity:    1,
+					LockedPrice: sdk.NewCoin(testDenom, sdkmath.NewInt(1)),
+				},
+			},
+			State:         types.LEASE_STATE_ACTIVE,
+			CreatedAt:     f.Ctx.BlockTime(),
+			LastSettledAt: f.Ctx.BlockTime(),
+		}))
+	}
+
+	resp, err := querier.CreditEstimate(f.Ctx, &types.QueryCreditEstimateRequest{
+		Tenant: tenant.String(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, sdkmath.NewInt(numLeases), resp.TotalRatePerSecond.AmountOf(testDenom),
+		"burn rate must sum all active leases, not truncate at the legacy 100 cap")
+	require.Equal(t, uint64(numLeases), resp.ActiveLeaseCount)
+}
+
+// TestQueryCreditAccount_IncludesActiveDenomBeyondLegacyCap verifies that a denom used
+// only by an active lease past position #100 still appears in the CreditAccount balances.
+// getRelevantDenomsForTenant must cap the active iteration by max_leases_per_tenant, not
+// the legacy hardcoded 100, or the tail denom's balance is silently omitted.
+func TestQueryCreditAccount_IncludesActiveDenomBeyondLegacyCap(t *testing.T) {
+	f := initFixture(t)
+	k := f.App.BillingKeeper
+	querier := keeper.NewQuerier(k)
+
+	tenant := f.TestAccs[0]
+
+	params, err := k.GetParams(f.Ctx)
+	require.NoError(t, err)
+	params.MaxLeasesPerTenant = 200
+	require.NoError(t, k.SetParams(f.Ctx, params))
+
+	creditAddr := types.DeriveCreditAddress(tenant)
+	require.NoError(t, k.SetCreditAccount(f.Ctx, types.CreditAccount{
+		Tenant:        tenant.String(),
+		CreditAddress: creditAddr.String(),
+	}))
+
+	const tailDenom = "tailactivedenom"
+	f.fundAccount(t, creditAddr, sdk.NewCoins(
+		sdk.NewCoin(testDenom, sdkmath.NewInt(1_000_000)),
+		sdk.NewCoin(tailDenom, sdkmath.NewInt(777)),
+	))
+
+	// 120 active leases; only the last (position 120, by ascending UUID) uses tailDenom. The
+	// TenantState MatchExact index iterates ascending by primary key (UUID), so the zero-padded
+	// UUIDs place the tail lease last — past the legacy cap of 100 but within the raised param cap.
+	const numLeases = 120
+	for i := range numLeases {
+		denom := testDenom
+		if i == numLeases-1 {
+			denom = tailDenom
+		}
+		require.NoError(t, k.SetLease(f.Ctx, types.Lease{
+			Uuid:         fmt.Sprintf("01912345-6789-7abc-8def-active%06d", i),
+			Tenant:       tenant.String(),
+			ProviderUuid: testProviderUUID,
+			Items: []types.LeaseItem{
+				{
+					SkuUuid:     "01912345-6789-7abc-8def-sku000000001",
+					Quantity:    1,
+					LockedPrice: sdk.NewCoin(denom, sdkmath.NewInt(1)),
+				},
+			},
+			State:         types.LEASE_STATE_ACTIVE,
+			CreatedAt:     f.Ctx.BlockTime(),
+			LastSettledAt: f.Ctx.BlockTime(),
+		}))
+	}
+
+	resp, err := querier.CreditAccount(f.Ctx, &types.QueryCreditAccountRequest{
+		Tenant: tenant.String(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, sdkmath.NewInt(777), resp.Balances.AmountOf(tailDenom),
+		"denom used only by an active lease past the legacy 100 cap must appear in balances")
+}
+
+// TestQueryCreditAccount_IncludesPendingDenomBeyondLegacyCap is the pending-state analogue:
+// the pending iteration in getRelevantDenomsForTenant must cap by max_pending_leases_per_tenant,
+// so a denom used only by a pending lease past position #100 still appears in balances.
+func TestQueryCreditAccount_IncludesPendingDenomBeyondLegacyCap(t *testing.T) {
+	f := initFixture(t)
+	k := f.App.BillingKeeper
+	querier := keeper.NewQuerier(k)
+
+	tenant := f.TestAccs[0]
+
+	params, err := k.GetParams(f.Ctx)
+	require.NoError(t, err)
+	params.MaxPendingLeasesPerTenant = 200
+	require.NoError(t, k.SetParams(f.Ctx, params))
+
+	creditAddr := types.DeriveCreditAddress(tenant)
+	require.NoError(t, k.SetCreditAccount(f.Ctx, types.CreditAccount{
+		Tenant:        tenant.String(),
+		CreditAddress: creditAddr.String(),
+	}))
+
+	const tailDenom = "tailpendingdenom"
+	f.fundAccount(t, creditAddr, sdk.NewCoins(
+		sdk.NewCoin(testDenom, sdkmath.NewInt(1_000_000)),
+		sdk.NewCoin(tailDenom, sdkmath.NewInt(555)),
+	))
+
+	// 120 pending leases; only the last (position 120, by ascending UUID) uses tailDenom. The
+	// TenantState MatchExact index iterates ascending by primary key (UUID), so the zero-padded
+	// UUIDs place the tail lease last — past the legacy cap of 100 but within the raised param cap.
+	const numLeases = 120
+	for i := range numLeases {
+		denom := testDenom
+		if i == numLeases-1 {
+			denom = tailDenom
+		}
+		require.NoError(t, k.SetLease(f.Ctx, types.Lease{
+			Uuid:         fmt.Sprintf("01912345-6789-7abc-8def-pending%05d", i),
+			Tenant:       tenant.String(),
+			ProviderUuid: testProviderUUID,
+			Items: []types.LeaseItem{
+				{
+					SkuUuid:     "01912345-6789-7abc-8def-sku000000001",
+					Quantity:    1,
+					LockedPrice: sdk.NewCoin(denom, sdkmath.NewInt(1)),
+				},
+			},
+			State:         types.LEASE_STATE_PENDING,
+			CreatedAt:     f.Ctx.BlockTime(),
+			LastSettledAt: f.Ctx.BlockTime(),
+		}))
+	}
+
+	resp, err := querier.CreditAccount(f.Ctx, &types.QueryCreditAccountRequest{
+		Tenant: tenant.String(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, sdkmath.NewInt(555), resp.Balances.AmountOf(tailDenom),
+		"denom used only by a pending lease past the legacy 100 cap must appear in balances")
+}
+
+// TestQueryCreditEstimate_ActiveCapBoundsIteration verifies the active-lease cap both (a) never
+// truncates a legitimately-reachable state and (b) still bounds iteration for a tenant with more
+// leases than the cap. With max_leases_per_tenant=5 and max_pending_leases_per_tenant=3 the cap is
+// min(5+3, upperBoundSum) = 8. A tenant can legitimately reach 7 active leases (the acknowledge
+// overshoot), so 7 and 8 leases must be summed in full; 9 and 12 must be bounded to 8. The
+// over-cap rows guard against a regression that drops the bound entirely.
+func TestQueryCreditEstimate_ActiveCapBoundsIteration(t *testing.T) {
+	const (
+		maxLeases  = 5
+		maxPending = 3
+		capLimit   = maxLeases + maxPending // 8
+	)
+
+	cases := []struct {
+		name       string
+		numLeases  int
+		expectRate int64
+	}{
+		{"below cap (overshoot band)", 7, 7},
+		{"exactly at cap", capLimit, capLimit},
+		{"one over cap", capLimit + 1, capLimit},
+		{"well over cap", 12, capLimit},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := initFixture(t)
+			k := f.App.BillingKeeper
+			querier := keeper.NewQuerier(k)
+			tenant := f.TestAccs[0]
+
+			params, err := k.GetParams(f.Ctx)
+			require.NoError(t, err)
+			params.MaxLeasesPerTenant = maxLeases
+			params.MaxPendingLeasesPerTenant = maxPending
+			require.NoError(t, k.SetParams(f.Ctx, params))
+
+			creditAddr := types.DeriveCreditAddress(tenant)
+			require.NoError(t, k.SetCreditAccount(f.Ctx, types.CreditAccount{
+				Tenant:        tenant.String(),
+				CreditAddress: creditAddr.String(),
+			}))
+			f.fundAccount(t, creditAddr, sdk.NewCoins(sdk.NewCoin(testDenom, sdkmath.NewInt(1_000_000_000))))
+
+			for i := range tc.numLeases {
+				require.NoError(t, k.SetLease(f.Ctx, types.Lease{
+					Uuid:         fmt.Sprintf("01912345-6789-7abc-8def-bound%07d", i),
+					Tenant:       tenant.String(),
+					ProviderUuid: testProviderUUID,
+					Items: []types.LeaseItem{{
+						SkuUuid:     "01912345-6789-7abc-8def-sku000000001",
+						Quantity:    1,
+						LockedPrice: sdk.NewCoin(testDenom, sdkmath.NewInt(1)),
+					}},
+					State:         types.LEASE_STATE_ACTIVE,
+					CreatedAt:     f.Ctx.BlockTime(),
+					LastSettledAt: f.Ctx.BlockTime(),
+				}))
+			}
+
+			resp, err := querier.CreditEstimate(f.Ctx, &types.QueryCreditEstimateRequest{Tenant: tenant.String()})
+			require.NoError(t, err)
+			require.Equal(t, sdkmath.NewInt(tc.expectRate), resp.TotalRatePerSecond.AmountOf(testDenom),
+				"active-lease rate sum must equal min(numLeases, cap)")
+		})
+	}
+}
+
+// TestQueryCreditEstimate_CoversAcknowledgeOvershoot drives real CreateLease/AcknowledgeLease
+// messages to reach the pending->active acknowledge overshoot (active count exceeds
+// max_leases_per_tenant), then verifies CreditEstimate counts and sums ALL active leases. This is
+// the end-to-end guard for the reachable-ceiling cap: a max_leases_per_tenant-only cap would
+// truncate the overshooting leases from the burn-rate sum.
+func TestQueryCreditEstimate_CoversAcknowledgeOvershoot(t *testing.T) {
+	f := initFixture(t)
+	k := f.App.BillingKeeper
+	msgServer := keeper.NewMsgServerImpl(k)
+	querier := keeper.NewQuerier(k)
+
+	tenant := f.TestAccs[0]
+	providerAddr := f.TestAccs[1]
+
+	// Low limits so the overshoot is reachable with a handful of messages:
+	// reachable active = MaxLeasesPerTenant-1 + MaxPendingLeasesPerTenant = 4 + 3 = 7 > MaxLeasesPerTenant(5).
+	params, err := k.GetParams(f.Ctx)
+	require.NoError(t, err)
+	params.MaxLeasesPerTenant = 5
+	params.MaxPendingLeasesPerTenant = 3
+	require.NoError(t, k.SetParams(f.Ctx, params))
+
+	provider := f.createTestProvider(t, providerAddr.String(), providerAddr.String())
+	sku := f.createTestSKU(t, provider.Uuid, 3600) // 3600 umfx/hour = 1 umfx/second per unit
+
+	creditAddr, err := types.DeriveCreditAddressFromBech32(tenant.String())
+	require.NoError(t, err)
+	require.NoError(t, k.SetCreditAccount(f.Ctx, types.CreditAccount{
+		Tenant:        tenant.String(),
+		CreditAddress: creditAddr.String(),
+	}))
+	f.fundAccount(t, creditAddr, sdk.NewCoins(sdk.NewCoin("umfx", sdkmath.NewInt(1_000_000_000))))
+
+	// createAndAck creates n pending leases (respecting the pending gate, n <= MaxPendingLeasesPerTenant)
+	// and acknowledges them, moving the active count up by n.
+	createAndAck := func(n int) {
+		uuids := make([]string, 0, n)
+		for range n {
+			resp, err := msgServer.CreateLease(f.Ctx, &types.MsgCreateLease{
+				Tenant: tenant.String(),
+				Items:  []types.LeaseItemInput{{SkuUuid: sku.Uuid, Quantity: 1}},
+			})
+			require.NoError(t, err)
+			uuids = append(uuids, resp.LeaseUuid)
+		}
+		_, err := msgServer.AcknowledgeLease(f.Ctx, &types.MsgAcknowledgeLease{
+			Sender:     providerAddr.String(),
+			LeaseUuids: uuids,
+		})
+		require.NoError(t, err)
+	}
+
+	createAndAck(3) // active 3
+	createAndAck(1) // active 4 = MaxLeasesPerTenant-1
+	createAndAck(3) // active 7 -> overshoot past MaxLeasesPerTenant(5)
+
+	ca, err := k.GetCreditAccount(f.Ctx, tenant.String())
+	require.NoError(t, err)
+	require.Equal(t, uint64(7), ca.ActiveLeaseCount, "sanity: overshoot state reached via real handlers")
+
+	resp, err := querier.CreditEstimate(f.Ctx, &types.QueryCreditEstimateRequest{Tenant: tenant.String()})
+	require.NoError(t, err)
+	require.Equal(t, uint64(7), resp.ActiveLeaseCount, "all overshoot active leases must be counted")
+	require.Equal(t, sdkmath.NewInt(7), resp.TotalRatePerSecond.AmountOf("umfx"),
+		"burn rate must sum all 7 active leases (1 umfx/sec each), not truncate at max_leases_per_tenant")
+}
+
+// TestQueryCreditAccount_ActiveDenomCapBounds verifies the denom-collection cap bounds iteration:
+// a denom used only by an active lease PAST the cap is excluded from the balances response. With
+// max_leases_per_tenant=5 and max_pending_leases_per_tenant=3 the active cap is 8, so a tail denom
+// on the 10th active lease (by ascending UUID) must not appear, while denoms within the cap do.
+func TestQueryCreditAccount_ActiveDenomCapBounds(t *testing.T) {
+	f := initFixture(t)
+	k := f.App.BillingKeeper
+	querier := keeper.NewQuerier(k)
+	tenant := f.TestAccs[0]
+
+	params, err := k.GetParams(f.Ctx)
+	require.NoError(t, err)
+	params.MaxLeasesPerTenant = 5
+	params.MaxPendingLeasesPerTenant = 3
+	require.NoError(t, k.SetParams(f.Ctx, params))
+
+	creditAddr := types.DeriveCreditAddress(tenant)
+	require.NoError(t, k.SetCreditAccount(f.Ctx, types.CreditAccount{
+		Tenant:        tenant.String(),
+		CreditAddress: creditAddr.String(),
+	}))
+
+	const tailDenom = "beyondcapdenom"
+	f.fundAccount(t, creditAddr, sdk.NewCoins(
+		sdk.NewCoin(testDenom, sdkmath.NewInt(1_000_000)),
+		sdk.NewCoin(tailDenom, sdkmath.NewInt(999)),
+	))
+
+	// 10 active leases (> cap of 8); tailDenom only on the last (position 10, ascending UUID).
+	const numLeases = 10
+	for i := range numLeases {
+		denom := testDenom
+		if i == numLeases-1 {
+			denom = tailDenom
+		}
+		require.NoError(t, k.SetLease(f.Ctx, types.Lease{
+			Uuid:         fmt.Sprintf("01912345-6789-7abc-8def-capbnd%06d", i),
+			Tenant:       tenant.String(),
+			ProviderUuid: testProviderUUID,
+			Items: []types.LeaseItem{{
+				SkuUuid:     "01912345-6789-7abc-8def-sku000000001",
+				Quantity:    1,
+				LockedPrice: sdk.NewCoin(denom, sdkmath.NewInt(1)),
+			}},
+			State:         types.LEASE_STATE_ACTIVE,
+			CreatedAt:     f.Ctx.BlockTime(),
+			LastSettledAt: f.Ctx.BlockTime(),
+		}))
+	}
+
+	resp, err := querier.CreditAccount(f.Ctx, &types.QueryCreditAccountRequest{Tenant: tenant.String()})
+	require.NoError(t, err)
+	require.True(t, resp.Balances.AmountOf(tailDenom).IsZero(),
+		"denom on a lease beyond the active cap must be excluded (iteration is bounded)")
+	require.Equal(t, sdkmath.NewInt(1_000_000), resp.Balances.AmountOf(testDenom),
+		"denoms within the cap must still be present")
+}
+
 // TestQueryErrorCasesComprehensive tests additional error cases across queries
 // including invalid UUID formats, non-existent resources, and malformed requests.
 func TestQueryErrorCasesComprehensive(t *testing.T) {

--- a/x/billing/simulation/operations.go
+++ b/x/billing/simulation/operations.go
@@ -311,6 +311,12 @@ func SimulateMsgCreateLease(txGen client.TxConfig, k keeper.Keeper, sk SKUKeeper
 
 		items := buildSimLeaseItems(r, providerSKUs[:numItems])
 
+		// Skip if the tenant cannot afford the lease; delivering it would fail with
+		// ErrInsufficientCredit and abort the simulation instead of being a valid NoOp.
+		if !tenantCanAffordLease(ctx, k, tenant.Address.String(), items, providerSKUs[:numItems], params.MinLeaseDuration) {
+			return simtypes.NoOpMsg(types.ModuleName, msgType, "tenant cannot afford lease"), nil, nil
+		}
+
 		msg := &types.MsgCreateLease{
 			Tenant: tenant.Address.String(),
 			Items:  items,
@@ -395,6 +401,11 @@ func SimulateMsgCreateLeaseForTenant(txGen client.TxConfig, k keeper.Keeper, sk 
 		})
 
 		items := buildSimLeaseItems(r, providerSKUs[:numItems])
+
+		// Skip if the tenant cannot afford the lease (see SimulateMsgCreateLease).
+		if !tenantCanAffordLease(ctx, k, tenant.Address.String(), items, providerSKUs[:numItems], params.MinLeaseDuration) {
+			return simtypes.NoOpMsg(types.ModuleName, msgType, "tenant cannot afford lease"), nil, nil
+		}
 
 		// Use the module authority as sender
 		// In simulation, we use the authority address from params
@@ -879,4 +890,57 @@ func buildSimLeaseItems(r *rand.Rand, skus []skutypes.SKU) []types.LeaseItemInpu
 		}
 	}
 	return items
+}
+
+// tenantCanAffordLease reports whether the tenant has enough AVAILABLE credit (balance minus
+// already-reserved amounts) to cover the reservation for the given lease items over
+// minLeaseDuration. It mirrors the credit check in the CreateLease message handler
+// (msg_server.go), so simulated leases that would be rejected with ErrInsufficientCredit are
+// skipped as a NoOp instead of aborting the whole simulation with a delivery error.
+func tenantCanAffordLease(ctx sdk.Context, k keeper.Keeper, tenant string, items []types.LeaseItemInput, skus []skutypes.SKU, minLeaseDuration uint64) bool {
+	skuByUUID := make(map[string]skutypes.SKU, len(skus))
+	for _, s := range skus {
+		skuByUUID[s.Uuid] = s
+	}
+
+	totalRatesPerSecond := sdk.NewCoins()
+	for _, item := range items {
+		s, ok := skuByUUID[item.SkuUuid]
+		if !ok {
+			return false
+		}
+		ratePerSecond, err := keeper.ConvertBasePriceToPerSecond(s.BasePrice, s.Unit)
+		if err != nil {
+			return false
+		}
+		totalRatesPerSecond = totalRatesPerSecond.Add(
+			sdk.NewCoin(ratePerSecond.Denom, ratePerSecond.Amount.Mul(sdkmath.NewIntFromUint64(item.Quantity))),
+		)
+	}
+
+	reservation := types.CalculateLeaseReservationFromRates(totalRatesPerSecond, minLeaseDuration)
+	if reservation.IsZero() {
+		return true
+	}
+
+	creditAccount, err := k.GetCreditAccount(ctx, tenant)
+	if err != nil {
+		return false
+	}
+	balances := sdk.NewCoins()
+	for _, res := range reservation {
+		bal, err := k.GetCreditBalance(ctx, tenant, res.Denom)
+		if err != nil {
+			return false
+		}
+		balances = balances.Add(bal)
+	}
+
+	available := types.GetAvailableCredit(balances, creditAccount.ReservedAmounts)
+	for _, res := range reservation {
+		if available.AmountOf(res.Denom).LT(res.Amount) {
+			return false
+		}
+	}
+	return true
 }

--- a/x/billing/types/keys.go
+++ b/x/billing/types/keys.go
@@ -82,10 +82,6 @@ const (
 	// MaxProviderWithdrawableQueryLimit is the maximum limit for ProviderWithdrawable queries.
 	// This prevents queries from iterating over unbounded numbers of leases.
 	MaxProviderWithdrawableQueryLimit uint64 = 1000
-
-	// MaxCreditEstimateLeases is the maximum number of active leases to process
-	// in a CreditEstimate query. This prevents DoS on tenants with many leases.
-	MaxCreditEstimateLeases uint64 = 100
 )
 
 // EndBlocker limits to prevent DoS attacks.


### PR DESCRIPTION
## Summary

Replaces the hardcoded `MaxCreditEstimateLeases = 100` constant with a **param-derived cap** at the two per-tenant lease-iteration query sites. The constant was a latent bug: its correct value is a function of the lease governance params, but it never tracked them, so it silently truncated once a tenant held more leases than 100.

Closes ENG-527. Unblocks ENG-528 (`MaxLeasesPerTenant` 100→200).

## The two truncation sites

1. **`CreditEstimate`** (`querier.go`) — capped the active-lease burn-rate sum at 100. For a tenant past the cap this **under-estimates burn → overestimates remaining runway** (the unsafe direction).
2. **`getRelevantDenomsForTenant`** (`keeper.go`, behind the `CreditAccount` query) — capped each of `{ACTIVE, PENDING}` at 100, so a denom used only by a lease past #100 was dropped from the balances response. This path is consumed by fred's withdraw scheduler.

## Fix

A shared helper centralises the reasoning:

```go
func maxReachableActiveLeases(params types.Params) uint64 {
	return min(
		params.MaxLeasesPerTenant+params.MaxPendingLeasesPerTenant,
		types.MaxLeasesPerTenantUpperBound+types.MaxPendingLeasesPerTenantUpperBound,
	)
}
```

- **Active** iterations (both sites) use `maxReachableActiveLeases`.
- **Pending** iteration uses `min(MaxPendingLeasesPerTenant, upperBound)`.

### Why the active cap is `MaxLeasesPerTenant + MaxPendingLeasesPerTenant`, not `MaxLeasesPerTenant`

`CreateLease` gates new (pending) leases on the *active* count, but `AcknowledgeLease` moves pending→active **without re-checking** that gate. So the reachable active count is `MaxLeasesPerTenant − 1 + MaxPendingLeasesPerTenant` — already **109 at today's 100/10 defaults**, not just after the ENG-528 bump. Sizing the cap to `MaxLeasesPerTenant` alone would still truncate that overshoot band; the reachable ceiling never truncates a legal state, and the clamp to the params' upper bounds (10000/1000) keeps it bounded against DoS.

## Deployment / sequencing

**Not consensus-critical** — reachable only from query handlers, not `msg_server` / `settlement` / EndBlocker. Ships as a **rolling node redeploy** (no coordinated upgrade, no gov/group action). Deploying it while the param is still 100 is harmless; landing it first makes the estimate correct at 200 the moment ENG-528 takes effect.

## Tests

- **Unit** — param-derived summation past 100; boundary + bounding table (proves the cap *bounds*, catching a cap-removal regression); active/pending tail-denom inclusion; denom-cap exclusion.
- **Integration (`msg_server`)** — `TestQueryCreditEstimate_CoversAcknowledgeOvershoot` drives real `CreateLease`/`AcknowledgeLease` to 7 active leases with `MaxLeasesPerTenant=5`, proving the overshoot is reachable through the real handlers and the query sums all 7.
- **E2E (interchaintest)** — `TestBillingCreditEstimateOvershoot` lowers the params, drives the overshoot via CLI txs, and asserts `CreditEstimate` over gRPC sums all active leases (`make ictest-billing`).

Full `x/billing/...` suite, `go vet`, and `golangci-lint` all pass; README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
