### PR TITLE
chore: prepare v2.3.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DOCKER := $(shell which docker)
 LEDGER_ENABLED ?= true
 BINDIR ?= $(GOPATH)/bin
 BUILD_DIR = ./build
-VERSION ?= v2.3.0
+VERSION ?= v2.3.1
 GO ?= go
 GOROOT := $(shell $(GO) env GOROOT)
 export GOROOT

--- a/interchaintest/chain_upgrade_test.go
+++ b/interchaintest/chain_upgrade_test.go
@@ -30,7 +30,7 @@ var (
 	// baseChain is the current version of the chain that will be upgraded from
 	baseChain = ibc.DockerImage{
 		Repository: "ghcr.io/manifest-network/manifest-ledger",
-		Version:    "2.2.1",
+		Version:    "2.3.0",
 		UIDGID:     "1025:1025",
 	}
 
@@ -126,7 +126,7 @@ func TestBasicManifestUpgrade(t *testing.T) {
 	haltHeight := height + haltHeightDelta
 
 	// The upgrade name must match app.Version() in the new binary
-	upgradeName := "v2.3.0"
+	upgradeName := "v2.3.1"
 
 	t.Logf("Upgrade name: %s", upgradeName)
 	t.Logf("Current height: %d, halt height: %d", height, haltHeight)


### PR DESCRIPTION
Release prep for **v2.3.1**, containing the ENG-527 fix (#168): credit-estimate lease caps derived from params (query-only, non-consensus).

## Changes
- `Makefile`: `VERSION` `v2.3.0` → `v2.3.1` (drives `app.Version()` and the `next.NewUpgrade(app.Version())` handler name).
- `interchaintest/chain_upgrade_test.go`: upgrade **FROM** `v2.3.0` **TO** `v2.3.1`.

## Deploy
Via governance upgrade (upgrade plan name = `v2.3.1`).

## After merge
Tag `v2.3.1` on the squash-merge commit and push to trigger goreleaser (binaries + GitHub Release) and the docker multi-arch workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)