### PR TITLE
docs(sku,billing): sync module documentation with code (v2.1.0→v2.3.1 audit)

### DIFF
--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -23,7 +23,7 @@ npm install @manifest-network/manifestjs
 npm install @cosmjs/proto-signing @cosmjs/stargate @cosmjs/tendermint-rpc
 ```
 
-manifestjs is a pure-codegen package — its semver tracks the proto surface, not chain releases. As of writing, mainnet runs `v2.1.0` of the chain and the matching client is `@manifest-network/manifestjs@^2.4`.
+manifestjs is a pure-codegen package — its semver tracks the proto surface, not chain releases. As of writing, mainnet runs `v2.3.1` of the chain; pin the `@manifest-network/manifestjs` range whose proto surface matches (see the [releases page](https://github.com/liftedinit/manifest-ledger/releases)).
 
 ## Query client (read path)
 
@@ -265,18 +265,22 @@ const withdraw = liftedinit.billing.v1.MessageComposer.encoded.withdraw({
   limit: 0n,
 });
 
-// Mode 2 — provider-wide (paginated):
+// Mode 2 — provider-wide (paginated). You MUST echo the cursor each round,
+// or the loop restarts from the first ACTIVE lease and never terminates.
 async function withdrawAll(providerUuid: string) {
+  let key = new Uint8Array();                   // empty = start from the beginning
   while (true) {
     const msg = liftedinit.billing.v1.MessageComposer.encoded.withdraw({
       sender: providerKey,
       leaseUuids: [],
       providerUuid,
       limit: 100n,                             // max 100; 0 = default 50
+      key,                                     // opaque cursor from the previous response
     });
     const res = await signingClient.signAndBroadcast(providerKey, [msg], "auto");
     const decoded = liftedinit.billing.v1.MsgWithdrawResponse.decode(res.msgResponses[0].value);
     if (!decoded.hasMore) return;              // stop when chain says no more
+    key = decoded.nextKey;                     // advance past the last processed lease
   }
 }
 ```
@@ -285,11 +289,22 @@ Read-only "what would I withdraw" estimates:
 
 ```ts
 const perLease = await client.liftedinit.billing.v1.withdrawableAmount({ leaseUuid });
-const provider = await client.liftedinit.billing.v1.providerWithdrawable({
-  providerUuid,
-  limit: 100n,
-});
-// provider.amounts (per-denom totals), provider.leaseCount, provider.hasMore
+
+// Provider-wide is paginated over the provider's ACTIVE leases; each response is
+// one PAGE, so sum across pages until the cursor is empty for the true total.
+let pageKey = new Uint8Array();
+const totals: Record<string, bigint> = {};
+do {
+  const page = await client.liftedinit.billing.v1.providerWithdrawable({
+    providerUuid,
+    pagination: { key: pageKey, limit: 100n },   // page size defaults to 100, capped at 1000
+  });
+  for (const c of page.amounts) totals[c.denom] = (totals[c.denom] ?? 0n) + BigInt(c.amount);
+  pageKey = page.pagination?.nextKey ?? new Uint8Array();
+} while (pageKey.length > 0);
+// `totals` = full per-denom withdrawable across ACTIVE leases.
+// page.amounts is this page's subtotal; page.leaseCount counts only leases with a
+// non-zero withdrawable amount in that page. (`limit`/`has_more` were removed in v2.2.0.)
 ```
 
 ### Tenant authentication to your provider API
@@ -299,8 +314,14 @@ After a lease goes ACTIVE, tenants prove ownership using ADR-036 arbitrary-messa
 ```ts
 const message = `manifest lease access ${leaseUuid} ${Math.floor(Date.now() / 1000)}`;
 const sig = await window.keplr.signArbitrary("manifest-1", tenant, message);
-// POST { tenant, lease_uuid, timestamp, pub_key: sig.pub_key, signature: sig.signature }
-//   to {provider.api_url}/v1/leases/{lease_uuid}/connection
+// Base64-encode the payload and send it as a Bearer token on a GET (not a POST body):
+const authToken = btoa(JSON.stringify({
+  tenant, lease_uuid: leaseUuid, timestamp: Math.floor(Date.now() / 1000),
+  pub_key: sig.pub_key, signature: sig.signature,
+}));
+await fetch(`${provider.api_url}/v1/leases/${leaseUuid}/connection`, {
+  headers: { Authorization: `Bearer ${authToken}` },   // GET
+});
 ```
 
 Use the same recipe with Leap (`window.leap.signArbitrary(...)`) — the API is identical. Web3Auth-derived signers reach this through `OfflineAminoSigner.signAmino`.
@@ -404,9 +425,13 @@ Common subscriptions for a provider control plane:
 |---|---|
 | New pending leases for me | `lease_created.provider_uuid='<UUID>'` |
 | Tenants cancelling pending leases | `lease_cancelled.provider_uuid='<UUID>'` |
-| Auto-close on credit exhaustion | `lease_auto_closed.provider_uuid='<UUID>'` |
+| Auto-close via provider-wide withdraw | `lease_auto_closed.provider_uuid='<UUID>'` |
+| Auto-close via `CloseLease` | `lease_closed.provider_uuid='<UUID>'`, then keep rows where `closed_by='credit_exhaustion'` |
+| Auto-close via specific-lease withdraw | `provider_withdraw.provider_uuid='<UUID>'`, then keep rows where `auto_closed='true'` |
 | Domain set on my leases | `lease_custom_domain_set.provider_uuid='<UUID>'` (v2.2.0+) |
 | Domain cleared on my leases | `lease_custom_domain_cleared.provider_uuid='<UUID>'` (v2.2.0+) |
+
+> **Credit exhaustion emits different events by path.** `lease_auto_closed` fires **only** from provider-wide withdraw. A close triggered by `MsgCloseLease` emits `lease_closed` with `closed_by='credit_exhaustion'`, and one triggered by a specific-lease `MsgWithdraw` emits `provider_withdraw` with `auto_closed='true'`. To catch *every* credit-exhaustion closure, watch all three.
 
 The full event catalogue and attributes live in [`x/billing/docs/API.md#events`](../x/billing/docs/API.md#events).
 

--- a/x/billing/README.md
+++ b/x/billing/README.md
@@ -167,7 +167,17 @@ If a tenant's credit balance is insufficient to cover accrued charges, the billi
 2. If accrued amount >= credit balance:
    - Performs final settlement (transfers available balance to provider)
    - Closes the lease automatically
-   - Emits a `lease_auto_closed` event with `reason: credit_exhausted`
+   - Emits an event whose type depends on the trigger path (see below)
+
+**Auto-close emits a different event on each path** — there is no single event that covers them all:
+
+| Trigger | Event | Distinguishing attribute |
+|---|---|---|
+| `MsgCloseLease` | `lease_closed` | `closed_by = credit_exhaustion` |
+| `MsgWithdraw` (specific lease UUIDs) | `provider_withdraw` | `auto_closed = true` (with `amount = 0`) |
+| `MsgWithdraw` (provider-wide) | `lease_auto_closed` | `reason = credit_exhausted` |
+
+A consumer that subscribes only to `lease_auto_closed` will miss credit-exhaustion closures triggered via `MsgCloseLease` or specific-lease `MsgWithdraw`.
 
 **Design rationale:**
 - **O(1) per lease check**: Instead of O(n) scanning all leases in EndBlock
@@ -238,10 +248,11 @@ These values are compile-time constants and cannot be changed via governance:
 | `MaxRejectionReasonLength` | 256 | Maximum characters for lease rejection reason |
 | `MaxClosureReasonLength` | 256 | Maximum characters for lease closure reason |
 | `MaxCustomDomainLength` | 253 | Maximum bytes for `LeaseItem.custom_domain` (RFC 1035 max FQDN length) |
+| `MaxWithdrawCursorLen` | 64 | Maximum bytes of the opaque `--key` cursor for provider-wide withdraw (a lease UUID is 36 bytes). Defined in `types/msgs.go`. |
 | `MaxDurationSeconds` | 3,153,600,000 (100 years) | Maximum lease duration for accrual calculations (overflow protection). Defined in `keeper/accrual.go`. |
 | `CreditAccountAddressPrefix` | `billing/credit/` | Prefix used for deterministic credit address derivation |
-| `DefaultProviderWithdrawableQueryLimit` | 100 | Default limit for ProviderWithdrawable query |
-| `MaxProviderWithdrawableQueryLimit` | 1000 | Maximum limit for ProviderWithdrawable query |
+| `DefaultProviderWithdrawableQueryLimit` | 100 | Default page size for the ProviderWithdrawable query (`pagination.limit`). The request's old top-level `limit` field was removed; proto field 2 is reserved. |
+| `MaxProviderWithdrawableQueryLimit` | 1000 | Maximum page size for the ProviderWithdrawable query (`pagination.limit` is clamped to this) |
 
 > **CreditEstimate / CreditAccount query iteration** is not a fixed constant — it tracks the lease params. The active-lease iteration is bounded by `max_leases_per_tenant + max_pending_leases_per_tenant`, a safe upper bound on the reachable active count: because `AcknowledgeLease` moves pending→active without re-gating the active limit, a tenant can reach `max_leases_per_tenant - 1 + max_pending_leases_per_tenant` active leases, and the cap adds a one-lease margin on top. The pending-lease iteration is bounded by `max_pending_leases_per_tenant`. Each is clamped to the params' upper bounds (10,000 / 1,000) as a hard safety ceiling, so the caps never truncate a legal state yet stay bounded against DoS.
 
@@ -260,7 +271,7 @@ Several messages support batch processing of multiple leases in a single transac
 
 **Atomic Batch Operations:** When providing specific lease UUIDs, the operation is atomic—all leases succeed or all fail. If any lease fails validation (wrong state, unauthorized, etc.), the entire transaction is rejected.
 
-**Provider-Wide Withdraw:** Unlike specific-lease operations, provider-wide withdraw is paginated. It processes up to `--limit` leases (default 50, max 100) and returns `has_more: true` plus an opaque `next_key` cursor if more remain. Pass `next_key` back as `--key` on the next call and repeat until `has_more: false`; calling again without `--key` restarts from the first lease.
+**Provider-Wide Withdraw:** Unlike specific-lease operations, provider-wide withdraw is paginated. It processes up to `--limit` leases (default 50, max 100) and returns `has_more: true` plus an opaque `next_key` cursor if more remain. Pass `next_key` back as `--key` on the next call and repeat until `has_more: false`; calling again without `--key` restarts from the first lease. Only ACTIVE leases are considered — CLOSED leases are already fully settled at close and are skipped, so every page is dense with ACTIVE leases. Leases are processed in ascending UUID order; `next_key` is the last lease UUID of the page and the next call resumes strictly after it.
 
 ### Lease
 
@@ -322,13 +333,13 @@ sender → credit_address
 
 ### Create Lease (PENDING)
 
-1. Verify tenant has a credit account
-2. Verify tenant has sufficient credit to cover minimum lease duration (credit >= rate * min_lease_duration)
-3. Verify all SKUs exist, are active, and belong to same provider
-4. Verify tenant hasn't exceeded max active or pending leases
-5. Lock current SKU prices
-6. Create lease in PENDING state
-7. Increment pending_lease_count
+1. Verify item count ≤ `max_items_per_lease`
+2. Verify tenant has a credit account
+3. Verify tenant hasn't exceeded max active or pending leases
+4. Verify all SKUs exist, are active, and belong to the same provider (locking per-second prices)
+5. Verify the provider exists and is active
+6. Verify `AvailableCredit >= rate × min_lease_duration` per denom and add the reservation
+7. Create lease in PENDING state and increment pending_lease_count
 
 ### Acknowledge Lease (PENDING → ACTIVE)
 
@@ -415,7 +426,7 @@ For detailed message definitions, request/response formats, and CLI usage, see [
 | CreditEstimate | Estimate remaining credit duration |
 | CreditAddress | Derive credit address for a tenant |
 | WithdrawableAmount | Get withdrawable amount for a lease |
-| ProviderWithdrawable | Get total withdrawable for a provider |
+| ProviderWithdrawable | Withdrawable amount across the provider's ACTIVE leases, one page at a time — sum `amounts` across pages until `pagination.next_key` is empty. `lease_count` counts only non-zero-withdrawable leases in the current page. |
 | LeaseByCustomDomain | Look up the active or pending lease that has claimed a given custom_domain (and the `service_name` of the matching item) |
 
 **Events**: See [API Reference - Events](docs/API.md#events) for the complete list of events emitted by this module.
@@ -528,7 +539,7 @@ invalid credit operation: tenant manifest1def... has lease reservations totaling
 - **Lease UUIDs**: All leases must have valid UUIDv7 format, no duplicates
 - **Tenant/Provider addresses**: All addresses must be valid bech32 format
 - **Credit address derivation**: Credit addresses must match deterministic derivation from tenant address
-- **Lease state consistency**: Timestamps must be consistent with lease state (e.g., `acknowledged_at` only for ACTIVE leases)
+- **Lease state consistency**: CLOSED leases must have a non-nil, non-zero `closed_at`. At InitGenesis, `created_at`, `last_settled_at`, and `closed_at` must not be after the block time.
 - **Parameter validation**: All params must pass validation constraints
 
 ## Additional Documentation
@@ -540,6 +551,7 @@ invalid credit operation: tenant manifest1def... has lease reservations totaling
 - [Integration Guide](docs/INTEGRATION.md) - Tenant authentication to provider APIs (ADR-036)
 - [Troubleshooting](docs/TROUBLESHOOTING.md) - Common errors and solutions
 - [API Reference](docs/API.md) - Complete CLI and gRPC/REST API reference
+- [Frontend / Integrator Cookbook](../../docs/FRONTEND.md) - Client-side signing recipes and the type-URL / amino-name reference table
 
 ### Developer Documentation
 - [Architecture](docs/ARCHITECTURE.md) - Internal architecture, data models, and flow diagrams

--- a/x/billing/docs/API.md
+++ b/x/billing/docs/API.md
@@ -313,6 +313,7 @@ manifestd tx billing withdraw --provider [provider-uuid] [flags]
 |------|------|---------|-------------|
 | --provider | string | - | Provider UUID for provider-wide withdrawal |
 | --limit | uint64 | 50 | Maximum leases to process in provider mode (max 100) |
+| --key | string | "" | Base64 `next_key` from the previous provider-wide withdraw response; continues paging. Rejected in specific-leases mode. |
 
 **Examples:**
 ```bash
@@ -340,6 +341,7 @@ manifestd tx billing withdraw --provider 01912345-6789-7abc-8def-0123456789ab --
   - Processes up to `limit` active leases
   - Response includes `has_more` and an opaque `next_key` cursor if more leases remain
   - Pass the returned `next_key` back as `--key` on the next call and repeat until `has_more` is false. Calling again *without* `--key` restarts from the first lease and never advances past `limit`.
+  - `--key` is only valid in provider-wide mode (setting it alongside lease UUIDs is rejected) and the decoded cursor may not exceed 64 bytes (`MaxWithdrawCursorLen`).
   - See [Provider-Wide Withdraw Workflow](#provider-wide-withdraw-workflow) below for example
 - Settles accrued amount since last settlement for each lease
 - Transfers aggregated amounts to provider's payout address
@@ -746,7 +748,7 @@ manifestd query billing withdrawable [lease-uuid]
 
 #### provider-withdrawable
 
-Query total withdrawable for a provider across all leases. **This query calculates real-time accrued amounts.**
+Query withdrawable amounts for a provider across the provider's ACTIVE leases, one page at a time. **This query calculates real-time accrued amounts.**
 
 ```bash
 manifestd query billing provider-withdrawable [provider-uuid]
@@ -929,6 +931,7 @@ manifestd query billing credit-estimate manifest1abc...
 **Limitations:**
 - **Bounded lease iteration**: The active-lease iteration is bounded by `max_leases_per_tenant + max_pending_leases_per_tenant` — a safe upper bound on the reachable active-lease count, clamped to the params' upper bounds (10,000 / 1,000) as a hard DoS ceiling. This covers every legitimately-reachable state, so `total_rate_per_second` and `active_lease_count` reflect all of a tenant's active leases and are not truncated at a fixed 100.
 - **Does not account for pending withdrawals**: The estimate uses current balance, not accounting for any unsettled accrued amounts from existing leases.
+- **Assumes constant rate**: The estimate assumes all current leases continue at their current rates. Actual duration may differ if leases are closed or new leases are created.
 
 ---
 
@@ -968,7 +971,6 @@ manifestd query billing lease-by-domain app.example.com
 - Returns the lease and the `service_name` of the LeaseItem that owns the domain. For a 1-item legacy lease the `service_name` is `""`.
 - Returns gRPC `NotFound` (CLI: error) when no PENDING/ACTIVE item has claimed the domain.
 - Backed by the `CustomDomainIndex` reverse-lookup (O(1)); domains held by closed/rejected/expired leases are not indexed.
-- **Assumes constant rate**: The estimate assumes all current leases continue at their current rates. Actual duration may differ if leases are closed or new leases are created.
 
 ---
 
@@ -990,6 +992,7 @@ service Msg {
   rpc CloseLease(MsgCloseLease) returns (MsgCloseLeaseResponse);
   rpc Withdraw(MsgWithdraw) returns (MsgWithdrawResponse);
   rpc UpdateParams(MsgUpdateParams) returns (MsgUpdateParamsResponse);
+  rpc SetItemCustomDomain(MsgSetItemCustomDomain) returns (MsgSetItemCustomDomainResponse);
 }
 ```
 
@@ -1204,6 +1207,7 @@ message MsgWithdraw {
   repeated string lease_uuids = 2; // Mode 1: specific lease UUIDs (1-100)
   string provider_uuid = 3;        // Mode 2: provider UUID for provider-wide withdrawal
   uint64 limit = 4;                // Max leases in provider mode (default 50, max 100)
+  bytes key = 5;                   // Mode 2: opaque cursor from the previous response's next_key; base64 in JSON. Must be empty in mode 1.
 }
 ```
 
@@ -1216,6 +1220,7 @@ message MsgWithdrawResponse {
   string payout_address = 2;        // Destination address
   uint64 withdrawal_count = 3;      // Number of leases processed
   bool has_more = 4;                // More leases remain (only true in provider-wide mode)
+  bytes next_key = 5;               // Opaque cursor; pass as MsgWithdraw.key for the next page. Non-empty iff has_more is true; always empty in lease_uuids mode.
 }
 ```
 
@@ -1274,7 +1279,7 @@ message MsgSetItemCustomDomainResponse {}
 - `lease_custom_domain_set` on a successful set.
 - `lease_custom_domain_cleared` on a successful clear (with the previous value in `custom_domain`).
 
-Both carry attributes `lease_uuid`, `tenant`, `service_name`, `custom_domain`, `set_by`. `set_by` ∈ `{tenant, authority, allowed}` records which authorisation path matched.
+Both carry attributes `lease_uuid`, `tenant`, `provider_uuid` (v2.2.0+), `service_name`, `custom_domain`, `set_by`. `set_by` ∈ `{tenant, authority, allowed}` records which authorisation path matched.
 
 ---
 
@@ -1599,6 +1604,15 @@ message Params {
 - `allowed_list`: Addresses with privileged authority for `MsgCreateLeaseForTenant` and `MsgSetItemCustomDomain`, in addition to the module authority.
 - `reserved_domain_suffixes`: DNS suffixes (each must begin with `.`) that tenants are forbidden from claiming as a `LeaseItem.custom_domain`. Match is case-insensitive at a label boundary, plus the apex (e.g. `.foo.example` matches both `app.foo.example` and `foo.example`). Each entry's substring after the leading dot must itself be a valid FQDN. Tunable via `MsgUpdateParams`.
 
+**Defaults and validation bounds (numeric params):**
+| Param | Default | Valid range |
+|-------|---------|-------------|
+| `max_leases_per_tenant` | 100 | 1 – 10,000 (`MaxLeasesPerTenantUpperBound`) |
+| `max_items_per_lease` | 20 | 1 – 100 (`MaxItemsPerLeaseHardLimit`) |
+| `min_lease_duration` | 3600 | 1 – 2,592,000 seconds / 30 days (`MaxMinLeaseDuration`) |
+| `max_pending_leases_per_tenant` | 10 | 1 – 1,000 (`MaxPendingLeasesPerTenantUpperBound`) |
+| `pending_timeout` | 1800 | 60 (`MinPendingTimeout`) – 86,400 (`MaxPendingTimeout`) seconds |
+
 ---
 
 ## Events
@@ -1616,16 +1630,22 @@ The billing module emits the following events for state changes:
 | `lease_cancelled` | lease_uuid, tenant, provider_uuid, cancelled_by | Tenant cancelled pending lease |
 | `batch_cancelled` | lease_count, tenant, cancelled_by | Batch summary when multiple leases cancelled |
 | `lease_expired` | lease_uuid, tenant, provider_uuid, reason | Pending lease expired |
-| `lease_closed` | lease_uuid, tenant, provider_uuid, settled_amounts, closed_by, duration_seconds, active_lease_count, closure_reason (optional) | Lease closed manually |
+| `lease_closed` | lease_uuid, tenant, provider_uuid, settled_amounts, closed_by, duration_seconds, active_lease_count, closure_reason (optional) | Lease closed (manually, or auto-closed on credit exhaustion) |
 | `batch_closed` | lease_count, closed_by, settled_amounts | Batch summary when multiple leases closed |
 | `lease_auto_closed` | lease_uuid, tenant, provider_uuid, reason | Lease auto-closed due to credit exhaustion |
-| `provider_withdraw` | lease_uuid, provider_uuid, payout_address | Provider withdrawal from single lease |
+| `provider_withdraw` | lease_uuid, amount, provider_uuid, payout_address | Provider withdrawal from single lease |
 | `batch_withdraw` | lease_count, provider_uuid, amount, payout_address, auto_closed | Batch summary when multiple leases withdrawn from |
 | `params_updated` | | Module parameters updated |
 | `lease_custom_domain_set` | lease_uuid, tenant, provider_uuid, service_name, custom_domain, set_by | `LeaseItem.custom_domain` set or changed (v2.1.0+; `provider_uuid` added v2.2.0+) |
 | `lease_custom_domain_cleared` | lease_uuid, tenant, provider_uuid, service_name, custom_domain (previous value), set_by | `LeaseItem.custom_domain` cleared (v2.1.0+; `provider_uuid` added v2.2.0+) |
 
 **Custom-domain `set_by` attribute:** records the role under which the call was authorised. One of `tenant`, `authority`, `allowed`. No event is emitted for an idempotent re-set or a clear of an already-empty domain.
+
+**`lease_closed` `closed_by` attribute:** records who closed the lease. One of `tenant`, `authority`, `provider`, or `credit_exhaustion`. `credit_exhaustion` is the auto-close sentinel set when lazy settlement finds the credit exhausted.
+
+**`batch_withdraw` `auto_closed` attribute:** emitted **only** in provider-wide mode, where it is an integer **count** of leases auto-closed during the batch (not a boolean). The specific-lease-UUID `batch_withdraw` path emits no `auto_closed` attribute.
+
+**Credit-exhaustion auto-close emits three events by path:** the same logical outcome surfaces as `lease_closed` (`closed_by=credit_exhaustion`) from the close path, `provider_withdraw` (`auto_closed="true"`) from specific-lease `MsgWithdraw`, and `lease_auto_closed` (`reason=credit_exhausted`) from provider-wide `MsgWithdraw`.
 
 **Special Case - Withdrawal Auto-Close:** When a `MsgWithdraw` operation discovers the lease's credit is exhausted (balance = 0), it automatically closes the lease. In this case, the `provider_withdraw` event includes an additional `auto_closed: "true"` attribute and `amount: "0"` to indicate no funds were transferred. Note that the `payout_address` attribute is omitted in this case since no transfer occurred.
 
@@ -1634,10 +1654,8 @@ The billing module emits the following events for state changes:
 Certain event attributes (like `rejection_reason` and `closure_reason`) are sanitized before being emitted to prevent log injection attacks. The original value is stored in state unchanged, but the sanitized version appears in events. This protects against malicious input containing control characters or log format strings.
 
 **Sanitization Rules:**
-- Control characters (ASCII 0-31, 127) are removed
-- Newlines (`\n`, `\r`) are replaced with spaces
-- Log format specifiers (e.g., `%s`, `%d`) are escaped
-- Maximum length enforced (256 characters for reasons)
+- Every rune that is not `unicode.IsGraphic` (control characters, including `\n` and `\r`) is removed outright — nothing is substituted in its place
+- No escaping or truncation is performed; reasons longer than 256 chars are rejected at ValidateBasic rather than truncated here
 
 **Example:**
 ```
@@ -1648,7 +1666,7 @@ reason: "Invalid config\nSee logs for details"
 rejection_reason: "Invalid config\nSee logs for details"
 
 # Emitted in event (sanitized):
-rejection_reason: "Invalid config See logs for details"
+rejection_reason: "Invalid configSee logs for details"
 ```
 
 ### Querying Events
@@ -1685,7 +1703,7 @@ manifestd query tx [txhash] --output json | jq -r '.logs[0].events[] | select(.t
 | `ErrMixedProviders` | 14 | SKUs from different providers in one lease |
 | `ErrNoWithdrawableAmount` | 15 | Nothing to withdraw |
 | `ErrEmptyLeaseItems` | 16 | Lease has no items |
-| `ErrInvalidQuantity` | 17 | Item quantity is zero |
+| `ErrInvalidQuantity` | 17 | Item quantity is zero, or exceeds `MaxQuantityPerItem` (1,000,000,000) |
 | `ErrDuplicateSKU` | 18 | Same SKU appears multiple times |
 | `ErrInvalidCreditOperation` | 19 | Credit operation failed |
 | `ErrReserved20` | 20 | Reserved for future use |
@@ -1693,7 +1711,7 @@ manifestd query tx [txhash] --output json | jq -r '.logs[0].events[] | select(.t
 | `ErrLeaseNotPending` | 22 | Lease is not in PENDING state |
 | `ErrMaxPendingLeasesReached` | 23 | Tenant at max pending leases |
 | `ErrInvalidRejectionReason` | 24 | Rejection reason too long (max 256 chars) |
-| `ErrInvalidRequest` | 25 | Invalid request (e.g., conflicting fields in MsgWithdraw) |
+| `ErrInvalidRequest` | 25 | Invalid request (e.g., conflicting fields in MsgWithdraw; setting `key` alongside `lease_uuids`; or a `key` longer than `MaxWithdrawCursorLen` = 64 bytes in provider-wide mode) |
 | `ErrInvalidClosureReason` | 26 | Closure reason too long (max 256 chars) |
 | `ErrInvalidMetaHash` | 27 | Meta hash exceeds maximum length (max 64 bytes) |
 | `ErrInvalidServiceName` | 28 | Invalid service name (must be RFC 1123 DNS label: 1-63 lowercase alphanumeric/hyphens, no leading/trailing hyphen) |
@@ -1708,7 +1726,7 @@ manifestd query tx [txhash] --output json | jq -r '.logs[0].events[] | select(.t
 **Why reserve codes?** During development, some error types were removed or consolidated (e.g., separate errors that were merged into a single error). Rather than renumbering all subsequent codes (which would break client error handling that relies on specific codes), the removed codes are marked as reserved. This ensures:
 - Existing client code that handles specific error codes continues to work after upgrades
 - Error codes in logs and metrics remain comparable across versions
-- New errors get the next available number (29+) rather than reusing gaps
+- New errors get the next number after the highest assigned code rather than reusing gaps
 
 **For developers:** Never assign new errors to reserved codes. Always use the next sequential number after the highest assigned code (currently 33).
 

--- a/x/billing/docs/ARCHITECTURE.md
+++ b/x/billing/docs/ARCHITECTURE.md
@@ -74,6 +74,7 @@ erDiagram
         uint64 quantity
         Coin locked_price
         string service_name
+        string custom_domain
     }
     
     PROVIDER {
@@ -184,10 +185,11 @@ graph LR
 
     subgraph "Reverse Lookup"
         CreditReverse[CreditAccountReverse<br/>Map: credit_addr → tenant_addr]
+        CustomDomainIdx[CustomDomainIndex<br/>Map: custom_domain → lease_uuid, prefix 0x0C]
     end
 
     subgraph "Sequences"
-        UUIDSeq[UUIDSequence<br/>uint64 per block]
+        LeaseSeq[LeaseSequence<br/>uint64, globally monotonic never reset]
     end
 ```
 
@@ -204,6 +206,7 @@ graph LR
 | `LeasesBySKU` | `(string, string)` | `bool` | Many-to-many SKU → leases index |
 | `LeasesByStateCreatedAt` | `(int32, time.Time, string)` | `bool` | Compound state+created_at → leases index (time-ordered) |
 | `CustomDomainIndex` | `string` (lower-cased domain) | `CustomDomainTarget` | Reverse lookup `custom_domain → (lease_uuid, service_name)` for O(1) `QueryLeaseByCustomDomain`. Reconciled by `SetLease` whenever lease items change; freed on close/reject/expire/auto-close. |
+| `LeaseSequence` | - | `uint64` | Monotonic counter feeding deterministic lease UUIDv7 generation |
 | `Params` | - | `Params` | Module parameters |
 
 ## Core Flows
@@ -270,46 +273,51 @@ sequenceDiagram
     
     User->>MsgServer: MsgCreateLease
     MsgServer->>MsgServer: ValidateBasic()
-    MsgServer->>Keeper: GetCreditAccount()
     
-    alt No Credit Account
-        Keeper-->>MsgServer: Error
-        MsgServer-->>User: Error
-    else Has Credit Account
-        Keeper-->>MsgServer: CreditAccount
+    alt len(items) > max_items_per_lease
+        MsgServer-->>User: Error: too many lease items
+    else Item Count OK
+        MsgServer->>Keeper: GetCreditAccount()
         
-        alt Exceeds max_pending_leases_per_tenant
-            MsgServer-->>User: Error: too many pending leases
-        else Under Pending Limit
-            MsgServer->>Keeper: GetCreditBalance()
+        alt No Credit Account
+            Keeper-->>MsgServer: Error
+            MsgServer-->>User: Error
+        else Has Credit Account
+            Keeper-->>MsgServer: CreditAccount
+            Note over MsgServer: counts read O(1) off CreditAccount<br/>(ActiveLeaseCount / PendingLeaseCount), not a scan
             
-            alt Balance < MinLeaseDuration Cost
-                MsgServer-->>User: Error: insufficient credit
-            else Sufficient Credit
-                MsgServer->>Keeper: CountActiveLeases()
-                
-                alt At Max Leases
-                    MsgServer-->>User: Error: max leases
-                else Under Limit
-                    loop For Each Item
-                        MsgServer->>SKU: GetSKU()
-                        alt SKU Invalid/Inactive
-                            SKU-->>MsgServer: Error
-                            MsgServer-->>User: Error
-                        else SKU OK
-                            SKU-->>MsgServer: SKU
-                            MsgServer->>MsgServer: Validate same provider
-                            MsgServer->>MsgServer: Build LeaseItem with locked_price
-                        end
+            alt ActiveLeaseCount >= max_leases_per_tenant
+                MsgServer-->>User: Error: max leases
+            else PendingLeaseCount >= max_pending_leases_per_tenant
+                MsgServer-->>User: Error: too many pending leases
+            else Under Limits
+                loop For Each Item
+                    MsgServer->>SKU: GetSKU()
+                    alt SKU Invalid/Inactive
+                        SKU-->>MsgServer: Error
+                        MsgServer-->>User: Error
+                    else SKU OK
+                        SKU-->>MsgServer: SKU
+                        MsgServer->>MsgServer: Validate same provider
+                        MsgServer->>MsgServer: Build LeaseItem with locked_price
                     end
-                    
-                    MsgServer->>Keeper: GenerateUUIDv7()
-                    MsgServer->>Store: Save Lease (state=PENDING)
-                    MsgServer->>Store: Update Indexes
-                    MsgServer->>Store: Add to PendingLeases index
-                    MsgServer->>Store: Increment pending_lease_count
-                    MsgServer->>MsgServer: Emit LeaseCreated Event
-                    MsgServer-->>User: Success + Lease UUID
+                end
+                
+                MsgServer->>SKU: GetProvider()
+                alt Provider Inactive
+                    MsgServer-->>User: Error: provider not active
+                else Provider Active
+                    Note over MsgServer: reservation = total_rate × min_lease_duration
+                    alt Available Credit < Reservation
+                        MsgServer-->>User: Error: insufficient credit
+                    else Sufficient Credit
+                        MsgServer->>Keeper: GenerateUUIDv7()
+                        MsgServer->>Store: Save Lease (state=PENDING)
+                        MsgServer->>Store: Update Indexes
+                        MsgServer->>Store: Increment pending_lease_count
+                        MsgServer->>MsgServer: Emit LeaseCreated Event
+                        MsgServer-->>User: Success + Lease UUID
+                    end
                 end
             end
         end
@@ -339,7 +347,7 @@ sequenceDiagram
             MsgServer->>SKU: GetProvider(lease.provider_uuid)
             SKU-->>MsgServer: Provider
             
-            alt Sender != Provider.Address
+            alt Sender != Provider.Address && Sender != authority
                 MsgServer-->>Provider: Error: unauthorized
             else Authorized
                 MsgServer->>Store: Set state = ACTIVE
@@ -378,7 +386,7 @@ sequenceDiagram
             MsgServer->>SKU: GetProvider(lease.provider_uuid)
             SKU-->>MsgServer: Provider
             
-            alt Sender != Provider.Address
+            alt Sender != Provider.Address && Sender != authority
                 MsgServer-->>Provider: Error: unauthorized
             else Authorized
                 MsgServer->>Store: Set state = REJECTED
@@ -406,36 +414,32 @@ sequenceDiagram
     
     Trigger->>Keeper: settleLease()
     Keeper->>Store: Get Lease
+    Keeper->>Keeper: Calculate Duration = settleTime − last_settled_at
+    Note over Keeper: State is not consulted (PerformSettlement is state-agnostic)
     
-    alt Lease Not ACTIVE
-        Keeper-->>Trigger: Skip (nothing to settle)
-    else Lease ACTIVE
-        Keeper->>Keeper: Get Current Time
-        Keeper->>Keeper: Calculate Duration Since last_settled_at
-        
-        alt Duration <= 0
-            Keeper-->>Trigger: Zero amount (nothing accrued)
-        else Duration > 0
-            loop For Each Item
-                Keeper->>Keeper: Calculate Accrual
-                Note over Keeper: accrual = duration_seconds × locked_price × quantity
-            end
-            
-            Keeper->>Keeper: Group by denom
-            Keeper->>Bank: Get Credit Balance per denom
-            
-            alt Accrued > Balance for any denom
-                Keeper->>Keeper: Cap Transfer to Balance
-            end
-            
-            alt Transfer Amount > 0
-                Keeper->>Bank: Transfer each denom to Provider Payout Address
-            end
-            
-            Keeper->>Store: Update last_settled_at
-            Keeper-->>Trigger: Settlement Amounts
+    alt Duration <= 0
+        Keeper-->>Trigger: Zero amounts (nothing accrued)
+    else Duration > 0
+        loop For Each Item
+            Keeper->>Keeper: Calculate Accrual
+            Note over Keeper: accrual = duration_seconds × locked_price × quantity
         end
+        
+        Keeper->>Keeper: Group by denom
+        Keeper->>Bank: Get Credit Balance per denom
+        
+        alt Accrued > Balance for any denom
+            Keeper->>Keeper: Cap Transfer to Balance
+        end
+        
+        alt Transfer Amount > 0
+            Keeper->>Bank: Transfer each denom to Provider Payout Address
+        end
+        
+        Keeper-->>Trigger: Settlement Amounts
     end
+    
+    Note over Keeper,Store: PerformSettlement / PerformSettlementSilent leave last_settled_at untouched;<br/>the caller (e.g. settleLease) persists last_settled_at = settleTime
 ```
 
 ### Close Lease with Settlement
@@ -464,12 +468,17 @@ sequenceDiagram
             alt Not Authorized
                 MsgServer-->>Sender: Error: unauthorized
             else Authorized
-                MsgServer->>Keeper: settleAndCloseLease()
-                Keeper->>Keeper: Calculate Final Settlement
+                alt ShouldAutoCloseLease (credit exhausted)
+                    Keeper->>Keeper: PerformSettlementSilent()
+                    Note over Keeper: closure_reason = "credit exhausted"<br/>closed_by = "credit_exhaustion" (msg.Reason ignored)
+                else Normal close
+                    Keeper->>Keeper: settleLease()
+                    Note over Keeper: closure_reason = msg.Reason
+                end
                 Keeper->>Bank: Transfer Settlement to Provider (per denom)
-                Keeper->>Store: Update Lease State to CLOSED
-                Keeper->>Store: Set closed_at
-                Keeper->>Store: Decrement active_lease_count
+                Keeper->>Store: SetLease (state = CLOSED, set closed_at)
+                Keeper->>Store: DecrementActiveLeaseCount
+                Keeper->>Store: ReleaseLeaseReservation
                 Keeper-->>MsgServer: Settlement Amounts
                 MsgServer->>MsgServer: Emit Events
                 MsgServer-->>Sender: Success
@@ -493,24 +502,28 @@ sequenceDiagram
     MsgServer->>Keeper: GetLease()
     Keeper-->>MsgServer: Lease
     
-    alt Lease Not ACTIVE
-        MsgServer-->>Provider: Error: not active
-    else Lease ACTIVE
-        MsgServer->>SKU: Get Provider for Lease
-        SKU-->>MsgServer: Provider
-        
-        alt Sender Not Provider/Authority
-            MsgServer-->>Provider: Error: unauthorized
-        else Authorized
-            MsgServer->>Keeper: settleLease()
-            Note over Keeper: Calculate and transfer accrued amount
-            
-            alt Nothing Settled
-                MsgServer-->>Provider: Error: no withdrawable amount
-            else Has Settlement
-                MsgServer->>MsgServer: Emit Event
-                MsgServer-->>Provider: Success + Amounts
+    MsgServer->>SKU: Get Provider for Lease
+    SKU-->>MsgServer: Provider
+    
+    alt Sender Not Provider/Authority
+        MsgServer-->>Provider: Error: unauthorized
+    else Authorized
+        loop For Each Target Lease (any state)
+            alt Lease ACTIVE and credit exhausted
+                MsgServer->>Keeper: ShouldAutoCloseLease + AutoCloseLease
+                Note over Keeper: settle to close time, auto-close lease
+            else Settle by state
+                Note over Keeper: ACTIVE → settle to blockTime<br/>closed_at != nil → settle to closed_at<br/>otherwise → settle to last_settled_at (zero duration)
+                MsgServer->>Keeper: PerformSettlement()
+                Note over Keeper: Skip lease if zero accrued
             end
+        end
+        
+        alt No lease withdrew or auto-closed
+            MsgServer-->>Provider: Error: no withdrawable amount
+        else Has Settlement
+            MsgServer->>MsgServer: Emit Event
+            MsgServer-->>Provider: Success + Amounts
         end
     end
 ```
@@ -658,10 +671,12 @@ writeFn()
 
 **Behavior**:
 - Each lease's settlement is atomic (all-or-nothing)
-- If settlement fails for one lease (e.g., overflow), only that lease is skipped
+- If settlement fails for one lease (e.g., a bank transfer error, a missing or invalid provider payout address, or a `last_settled_at` that is after the block time), only that lease is skipped
 - Other leases in the batch are processed normally
 - Failed leases don't affect the success of the overall operation
 - Provider can retry failed leases individually using specific lease UUIDs
+
+> **Accrual overflow is NOT a skip.** If a lease's accrued charge overflows — the settlement duration exceeds `MaxDurationSeconds` (~100 years, `keeper/accrual.go`) — the silent settlement path (`PerformSettlementSilent`) does *not* skip and does *not* preserve the funds. It sets the accrued amount to the tenant's entire remaining credit in that lease's denoms and transfers it to the provider (`keeper/settlement.go`), and `ShouldAutoCloseLease` force-closes the lease. This is deliberate — zeroing it out would grant free service to the tenant. Overflow is effectively unreachable in normal operation (a lease would have to go ~100 years without settlement) but can arise from a genesis import with an ancient `last_settled_at`.
 
 This pattern ensures that partial failures don't corrupt state while still providing best-effort batch processing.
 
@@ -697,29 +712,50 @@ Leases that remain in `PENDING` state beyond the `pending_timeout` (default 30 m
 func (k Keeper) EndBlocker(ctx context.Context) error {
     sdkCtx := sdk.UnwrapSDKContext(ctx)
     now := sdkCtx.BlockTime()
-    params := k.GetParams(ctx)
+    params, err := k.GetParams(ctx)
+    if err != nil {
+        return err
+    }
     pendingTimeout := time.Duration(params.PendingTimeout) * time.Second
 
     // Two-pass approach to avoid iterator invalidation
     // Pass 1: Collect UUIDs of expired pending leases
-    iter := k.Leases.Indexes.State.MatchExact(ctx, LEASE_STATE_PENDING)
+    iter, err := k.Leases.Indexes.State.MatchExact(ctx, int32(types.LEASE_STATE_PENDING))
+    if err != nil {
+        return err
+    }
     var expiredUUIDs []string
 
     for ; iter.Valid(); iter.Next() {
-        if len(expiredUUIDs) >= MaxPendingLeaseExpirationsPerBlock {
+        if len(expiredUUIDs) >= types.MaxPendingLeaseExpirationsPerBlock {
             break // Rate limit: max 100 per block
         }
-        lease := iter.Value()
+        leaseUUID, err := iter.PrimaryKey()
+        if err != nil {
+            // per-lease errors are logged and skipped, never fatal
+            continue
+        }
+        lease, err := k.Leases.Get(ctx, leaseUUID)
+        if err != nil {
+            continue
+        }
         expirationTime := lease.CreatedAt.Add(pendingTimeout)
         if now.After(expirationTime) {
-            expiredUUIDs = append(expiredUUIDs, lease.Uuid)
+            expiredUUIDs = append(expiredUUIDs, leaseUUID)
         }
     }
     iter.Close()
 
-    // Pass 2: Expire collected leases (safe to modify state)
-    for _, uuid := range expiredUUIDs {
-        k.ExpirePendingLease(ctx, uuid)
+    // Pass 2: Expire collected leases (safe to modify state).
+    // Each lease is re-fetched; per-lease errors are logged and skipped, never fatal.
+    for _, leaseUUID := range expiredUUIDs {
+        lease, err := k.Leases.Get(ctx, leaseUUID)
+        if err != nil {
+            continue
+        }
+        if err := k.ExpirePendingLease(ctx, &lease); err != nil {
+            continue
+        }
     }
 
     return nil
@@ -742,8 +778,9 @@ When a lease expires:
 - State changes from `PENDING` → `EXPIRED`
 - `expired_at` timestamp is set
 - `pending_lease_count` is decremented
+- The lease's reservation is released from `CreditAccount.reserved_amounts` (via `ReleaseLeaseReservation`), freeing the credit for new leases
 - Credit remains in tenant's account (was never billed since lease never activated)
-- `LeaseExpired` event is emitted
+- The whole expiration is `CacheContext`-atomic; the `lease_expired` event is emitted on the parent context after commit
 
 ## Credit Account Multi-Denom Support
 
@@ -797,8 +834,10 @@ The `locked_price` stored in `LeaseItem` is already the per-second rate, calcula
 
 ```go
 // During lease creation
-lockedPricePerSecond = skutypes.CalculatePricePerSecond(sku.BasePrice, sku.Unit)
+lockedPricePerSecond, err := ConvertBasePriceToPerSecond(sku.BasePrice, sku.Unit)
 ```
+
+`ConvertBasePriceToPerSecond` (`x/billing/keeper/accrual.go`) wraps `skutypes.CalculatePricePerSecond`, re-attaching the SKU's `base_price` denom so the result is an `sdk.Coin` suitable for `LeaseItem.locked_price`. It returns an error on unknown unit, a zero per-second rate, or inexact division; at lease creation this surfaces as `ErrSKUNotFound.Wrapf("invalid SKU pricing: %s", err)`.
 
 ### Accrual Formula
 
@@ -871,7 +910,7 @@ This returns `sdk.Coins` to support multi-denom leases where different SKUs may 
 5. **Min lease duration** - Prevents immediate exhaustion
 6. **Lazy settlement** - No per-block overhead for accrual calculation
 7. **EndBlocker rate limiting** - Max 100 pending lease expirations per block
-8. **Indexed lookups** - O(1) credit account detection
+8. **Indexed lookups** - `CreditAddressIndex` (prefix 6) is a maintained reverse index (`credit_address → tenant`) written by `SetCreditAccount`. It is not read anywhere in the current tree, but enables O(1) credit-account detection for future or off-chain consumers
 9. **Same provider requirement** - Simplifies acknowledgement flow
 
 ## Performance Characteristics
@@ -887,7 +926,6 @@ This returns `sdk.Coins` to support multi-denom leases where different SKUs may 
 | Withdraw (specific) | O(m) | m = items in lease |
 | Withdraw (provider) | O(k×m) | k = leases (max 100), m = avg items |
 | GetCreditBalance | O(1) | Bank query |
-| isCreditAccount | O(1) | Reverse lookup map |
 | GetLeasesByTenant | O(n) | n = tenant's leases |
 | GetLeasesByTenant (with state filter) | O(k) | k = matching leases (compound index) |
 | GetLeasesByProvider | O(n) | n = provider's leases |
@@ -1022,7 +1060,7 @@ When a provider or SKU is deactivated:
 
 *SKUs must be individually reactivated via `update-sku` after provider reactivation.
 
-**Cascade behavior**: When `DeactivateProvider` is called, the SKU module automatically deactivates all SKUs under that provider in the same transaction. This ensures consistency - an inactive provider has no active SKUs.
+**Cascade behavior**: `DeactivateProvider` deactivates the provider immediately and then deactivates its active SKUs in pages of `limit` (default 50, max 100). If the response's `has_more` is `true`, active SKUs remain and the caller must re-invoke `DeactivateProvider` with the same UUID until `has_more == false`. Until the cascade completes, an inactive provider may transiently still have active SKUs.
 
 **Implementation note**: The billing module queries SKU/provider status at lease creation time. Existing leases store `provider_uuid` and `locked_price`, making them independent of subsequent provider/SKU state changes. Tenants can close their leases at any time, even after provider/SKU deactivation.
 

--- a/x/billing/docs/CAPABILITIES.md
+++ b/x/billing/docs/CAPABILITIES.md
@@ -38,9 +38,6 @@ This document provides a comprehensive overview of the Billing module's capabili
 ## Lease Lifecycle
 
 ```
-    ┌─────────────────────────────────────────────────────────┐
-    │                                                         │
-    ▼                                                         │
 ┌─────────┐    acknowledge    ┌─────────┐    close/exhaust   ┌─────────┐
 │ PENDING │ ───────────────► │ ACTIVE  │ ─────────────────► │ CLOSED  │
 └─────────┘                   └─────────┘                    └─────────┘
@@ -90,7 +87,7 @@ This design enables:
 When credit is exhausted:
 1. Transfer available balance to provider (partial payment)
 2. Auto-close the lease
-3. Emit `lease_auto_closed` event with reason `credit_exhausted`
+3. Emit an auto-close event whose type depends on the path: `lease_auto_closed` (reason=`credit_exhausted`) from provider-wide withdraw; `lease_closed` with `closed_by=credit_exhaustion` from CloseLease; `provider_withdraw` with `auto_closed=true` from specific-lease withdraw
 
 ### Overflow Protection
 
@@ -114,7 +111,7 @@ When credit is exhausted:
 | `CreditEstimate` | Estimated remaining duration based on active leases |
 | `CreditAddress` | Derive credit address for a tenant |
 | `WithdrawableAmount` | Accrued amount for a specific lease |
-| `ProviderWithdrawable` | Total withdrawable across all provider's leases |
+| `ProviderWithdrawable` | Withdrawable amount across the provider's ACTIVE leases, one page at a time — sum `amounts` across pages until `pagination.next_key` is empty for the provider total |
 | `LeaseByCustomDomain` | Look up the PENDING/ACTIVE lease + item that owns a given `custom_domain` (v2.1.0+) |
 
 ---
@@ -189,10 +186,7 @@ For the complete authorization matrix, see [API Reference - Authorization](API.m
 
 | Improvement | Description | Benefit |
 |-------------|-------------|---------|
-| **Extract Auto-Close Helper** | DRY up duplicated logic in withdraw functions | Maintainability |
-| **Stateful Pagination for Provider Withdraw** | Cursor-based iteration | Handle 1000s of leases efficiently |
 | **Event Indexing** | Structured event data for indexers | Better off-chain analytics |
-| **Simulation Tests** | Fuzz testing for billing math | Confidence in edge cases |
 | **Gas Optimization** | Batch state writes | Lower transaction costs |
 
 ### Integration Improvements

--- a/x/billing/docs/COMPARISON.md
+++ b/x/billing/docs/COMPARISON.md
@@ -66,7 +66,7 @@ Akash is a decentralized cloud compute marketplace with on-chain order matching 
 | Consideration | Current State | Future Improvement |
 |---------------|---------------|-------------------|
 | **Soft deletes** | Closed leases remain in state forever | Consider archival/pruning after X days |
-| **Index overhead** | 5+ indexes per lease (tenant, provider, state, SKU, time) | Monitor storage costs at scale |
+| **Index overhead** | 8 indexes per lease (tenant, provider, state, provider+state, tenant+state, SKU, state+created_at, custom_domain) | Monitor storage costs at scale |
 | **Provider/SKU accumulation** | Inactive entities never removed | Acceptable - provides audit trail |
 
 ### Estimated State Sizes
@@ -150,7 +150,7 @@ This section provides a detailed technical comparison of the internal architectu
 | **Module Coupling** | High - tight dependencies between deployment/market/escrow | Lower - cleaner separation between sku/billing |
 | **Escrow Approach** | Dedicated `x/escrow` module with separate account types | Integrated into `x/billing` using derived credit addresses (bank module) |
 | **Provider Registration** | Separate `x/provider` + `x/audit` for attestations | Combined in `x/sku` (Provider + SKU entities) |
-| **Lines of Code** | ~15,000+ across escrow/market/deployment | ~3,500 in billing module |
+| **Lines of Code** | ~15,000+ across escrow/market/deployment | ~8,000 hand-written Go in billing module (keeper ~4.2K, types ~1.4K, CLI ~1.3K, simulation ~1.0K; excludes tests and generated .pb.go) |
 
 ### Leasing System
 
@@ -261,25 +261,32 @@ Manifest handles side effects inline where they occur. For example, in `CloseLea
 
 ```go
 // In msg_server.go - CloseLease
-// 1. Settlement
-result, err := ms.k.PerformSettlement(cacheCtx, &lease, closeTime)
+// 1. Settlement (branch depends on whether credit is exhausted)
+shouldAutoClose, autoCloseTime, err := ms.k.ShouldAutoCloseLease(cacheCtx, &leases[i])
+if shouldAutoClose {
+    // Credit exhausted: settle in silent mode (doesn't fail on overflow)
+    result, err := ms.k.PerformSettlementSilent(cacheCtx, &leases[i], autoCloseTime)
+    settledAmounts = result.TransferAmounts
+} else {
+    // Normal close: settle accrued charges up to block time
+    settledAmounts, err = ms.settleLease(cacheCtx, &leases[i], closeTime)
+}
 
 // 2. State update
-lease.State = types.LEASE_STATE_CLOSED
-lease.ClosedAt = &closeTime
+leases[i].State = types.LEASE_STATE_CLOSED
+leases[i].ClosedAt = &closeTime
 
 // 3. Persist lease
-if err := ms.k.SetLease(cacheCtx, lease); err != nil { ... }
+if err := ms.k.SetLease(cacheCtx, leases[i]); err != nil { ... }
 
 // 4. Update credit account counts
-ms.k.DecrementActiveLeaseCount(&creditAccount, lease.Uuid)
+ms.k.DecrementActiveLeaseCount(&creditAccount, leases[i].Uuid)
 
 // 5. Release reservation
-reservationAmount := types.CalculateLeaseReservation(lease.Items, params.MinLeaseDuration)
-creditAccount.ReservedAmounts = types.SubtractReservation(
-    creditAccount.ReservedAmounts,
-    reservationAmount,
-)
+// GetLeaseReservationAmount prefers lease.MinLeaseDurationAtCreation (when
+// non-zero) over the current param, so leases created under a different
+// min_lease_duration release the correct amount.
+ms.k.ReleaseLeaseReservation(&creditAccount, &leases[i], params.MinLeaseDuration)
 
 // 6. Save credit account
 if err := ms.k.SetCreditAccount(cacheCtx, creditAccount); err != nil { ... }

--- a/x/billing/docs/DESIGN_DECISIONS.md
+++ b/x/billing/docs/DESIGN_DECISIONS.md
@@ -285,12 +285,12 @@ Item 2: SKU 2 (priced in 'umfx') - locked_price: 500umfx/second
 
 ## Decision 13: Maximum Limits as DoS Protection
 
-**Decision:** Impose configurable limits on leases per tenant, items per lease, and withdrawal batch size.
+**Decision:** Impose configurable limits on leases per tenant and items per lease, plus hard-coded (non-governable) batch/cursor limits.
 
 **Alternatives Considered:**
 1. No limits (rely on gas)
 2. Hard-coded limits
-3. Configurable parameter limits (chosen)
+3. Configurable parameter limits for the per-tenant/per-lease bounds (chosen), with compile-time constants for batch/cursor sizes
 
 **Rationale:**
 - **DoS Prevention:** Bounds computation
@@ -310,7 +310,11 @@ Item 2: SKU 2 (priced in 'umfx') - locked_price: 500umfx/second
 | `max_items_per_lease` | 20 | 100 |
 | `min_lease_duration` | 3600s | 2,592,000s (30 days) |
 | `max_pending_leases_per_tenant` | 10 | 1,000 |
-| Provider withdraw batch | 50 | 100 |
+| `pending_timeout` | 1800s | 60s – 86,400s (min–max) |
+
+`pending_timeout` is the only param with a lower bound: 0 is rejected by the minimum check (`MinPendingTimeout` = 60s), not a separate zero check.
+
+The provider withdraw batch limits are **not** governance parameters — they are compile-time constants (`DefaultProviderWithdrawLimit` = 50, `MaxBatchLeaseSize` = 100) and require a binary release to change, not a param update.
 
 ## Decision 14: Minimum Lease Duration
 
@@ -334,11 +338,18 @@ Item 2: SKU 2 (priced in 'umfx') - locked_price: 500umfx/second
 
 **Implementation:**
 ```go
-minRequired = totalRatePerSecond * minLeaseDuration
-if creditBalance < minRequired {
-    return ErrInsufficientCredit
-}
+reservation = totalRatePerSecond * minLeaseDuration              // sdk.Coins, per denom
+availableCredit = creditBalance - creditAccount.reserved_amounts // per denom
+for each denom in reservation:
+    if availableCredit[denom] < reservation[denom] {
+        return ErrInsufficientCredit
+    }
 ```
+
+The check is against *available* credit (balance minus existing reservations), evaluated
+per-denom, not against the raw balance as a single scalar. On success the reservation is
+added to `CreditAccount.ReservedAmounts` and `min_lease_duration_at_creation` is snapshotted
+on the lease so the reservation can be released consistently later.
 
 ## Decision 15: UUIDv7 for Identifiers
 
@@ -411,7 +422,7 @@ if creditBalance < minRequired {
 
 **Trade-offs:**
 - EndBlocker overhead (mitigated by rate limiting)
-- Need efficient time-ordered index
+- Scans the PENDING state index in index order (not `created_at` order) with per-lease time filtering. The StateCreatedAt index (prefix 11) exists but is unusable because collections' `PairRange` cannot do partial-prefix ranges on `Pair[int32, time.Time]`. Consequence: with >100 pending leases, the first 100 index entries are examined regardless of age, so older expired leases may wait for a later block.
 - Max pending leases per tenant limit needed
 
 ## Decision 18: Tenant Cancellation of Pending Leases
@@ -431,9 +442,27 @@ if creditBalance < minRequired {
 - Additional message type (CancelLease)
 - Provider may have started provisioning (off-chain race)
 
+## Decision 19: Compute-Specific Lease Item Fields (service_name / custom_domain)
+
+**Decision:** Carry the compute-specific `service_name` and `custom_domain` fields directly on the generic `LeaseItem` rather than in a dedicated deployment module.
+
+**Alternatives Considered:**
+1. Wait for a dedicated `x/deployment` module before shipping these fields
+2. Generic key/value metadata bag on the lease item
+3. Compute-specific fields on `LeaseItem` as a pragmatic shortcut (chosen)
+
+**Rationale:**
+- **Pragmatic Shortcut:** `service_name` (field 4) and `custom_domain` (field 5) are marked COMPUTE-SPECIFIC in the proto and conceptually belong in a future `x/deployment` module; they live on the generic lease item today to ship the feature without a new module. Migration path tracked as ENG-80.
+- **Dual-Mode Uniqueness:** In legacy mode uniqueness is enforced on `sku_uuid` (each SKU unique per lease); in service-name mode all items must set `service_name` and uniqueness shifts to `service_name`, allowing the same SKU to appear multiple times (e.g., `web` and `db` both on `docker-small`).
+- **Reverse Lookup:** `custom_domain` drives the `CustomDomainIndex` (prefix 12) for O(1) reverse lookup and uniqueness enforcement.
+
+**Trade-offs:**
+- **Multi-Item Legacy Leases Cannot Host a Custom Domain:** A multi-item lease created in legacy mode (no `service_name`) has no unambiguous way to address an item, so it is rejected from setting a `custom_domain` (`ErrAmbiguousLeaseItem`).
+- **`reserved_domain_suffixes` Ships Empty:** `Params.ReservedDomainSuffixes` defaults to `nil` on purpose and `Migrate1to2` is a no-op. Once a hostname is baked into a release tag it cannot be unshipped from chains that already ran the upgrade, so operators seed provider wildcard zones via genesis or post-upgrade `MsgUpdateParams` instead. (ENG-82 tracks provider-declared zones in `x/sku`.)
+
 ## Future Considerations
 
-### Potential Enhancements for v2
+### Potential Future Enhancements
 
 1. **Lease Pruning:** Archive old leases to reduce state size
 2. **Tiered Pricing:** Volume discounts based on usage

--- a/x/billing/docs/INTEGRATION.md
+++ b/x/billing/docs/INTEGRATION.md
@@ -4,12 +4,12 @@ This guide covers how tenants authenticate to provider off-chain APIs after leas
 
 ## Provider Off-Chain API Integration
 
-Providers expose a REST API for tenants to retrieve connection details after lease acknowledgement. The API endpoint URL is stored on-chain in the `Provider.api_url` field.
+Providers expose a REST API for tenants to retrieve connection details after lease acknowledgement. The API endpoint URL is stored on-chain in the `Provider.api_url` field. This field is optional and may be empty (a provider that never set one returns `null`); tenants and clients must handle the absent case, in which the provider has no off-chain API registered.
 
 ### Tenant Flow
 
 1. Tenant queries lease to get `provider_uuid`
-2. Tenant queries provider to get `api_url`
+2. Tenant queries provider to get `api_url` (may be empty if the provider registered no off-chain API)
 3. Tenant calls provider's API with signature-based authentication
 
 ### Authentication
@@ -135,6 +135,7 @@ For Go-based providers, use the `@keplr-wallet/cosmos` package's verification lo
   "endpoints": [
     {
       "sku_uuid": "01912345-6789-7abc-8def-0123456789ab",
+      "service_name": "web",
       "type": "ssh",
       "host": "192.168.1.100",
       "port": 22,
@@ -148,6 +149,8 @@ For Go-based providers, use the `@keplr-wallet/cosmos` package's verification lo
   "provisioned_at": "2024-12-16T19:30:00Z"
 }
 ```
+
+When a lease is created in service-name mode (`sku-uuid:quantity:service_name`), the same `sku_uuid` may appear across multiple items, so `service_name` — not `sku_uuid` — is the unique key for a lease's endpoints. Legacy single-item leases (`sku-uuid:quantity`) omit `service_name` and are keyed by `sku_uuid`.
 
 ### Security Considerations
 
@@ -187,6 +190,8 @@ For providers with fixed SKUs (pre-configured resources), tenants create leases 
 ```
 
 **Important**: Upload deployment data BEFORE the provider acknowledges. This allows the provider to validate the manifest and provision resources before committing to the lease.
+
+**Pending timeout**: The entire upload → validate → provision → acknowledge sequence must complete within `params.pending_timeout` (default 1800s = 30 minutes; configurable 60..86400 seconds via `MsgUpdateParams`). If the provider does not acknowledge before the lease's `created_at + pending_timeout`, the EndBlocker transitions the lease to `LEASE_STATE_EXPIRED` and releases the tenant's credit reservation. The tenant must then create a new lease (and re-upload the deployment data); any payload already uploaded to the provider is orphaned.
 
 ### On-Chain Storage
 

--- a/x/billing/docs/INTEGRATION.md
+++ b/x/billing/docs/INTEGRATION.md
@@ -4,7 +4,7 @@ This guide covers how tenants authenticate to provider off-chain APIs after leas
 
 ## Provider Off-Chain API Integration
 
-Providers expose a REST API for tenants to retrieve connection details after lease acknowledgement. The API endpoint URL is stored on-chain in the `Provider.api_url` field. This field is optional and may be empty (a provider that never set one returns `null`); tenants and clients must handle the absent case, in which the provider has no off-chain API registered.
+Providers expose a REST API for tenants to retrieve connection details after lease acknowledgement. The API endpoint URL is stored on-chain in the `Provider.api_url` field. This field is optional: it is a proto3 `string` with `omitempty`, so a provider that never set one leaves it as the empty string, omitted from JSON output (a `jq -r '.provider.api_url'` prints `null` for the missing key — it is never a literal JSON `null` value). Tenants and clients must handle this absent case, in which the provider has no off-chain API registered.
 
 ### Tenant Flow
 

--- a/x/billing/docs/MIGRATION.md
+++ b/x/billing/docs/MIGRATION.md
@@ -48,6 +48,10 @@ manifestd tx billing update-params \
 | `min_lease_duration` | Min seconds credit must cover | 3600 |
 | `max_pending_leases_per_tenant` | Max pending leases per tenant | 10 |
 | `pending_timeout` | Seconds before pending lease expires | 1800 |
+| `allowed_list` | Addresses allowed to create leases for tenants | `[]` |
+| `reserved_domain_suffixes` | DNS suffixes tenants may not claim as a `custom_domain`; each must begin with `.` | empty |
+
+**Note:** `--allowed-list` and `--reserved-domain-suffixes` are preserve-on-omit: when the flag is absent the CLI round-trips the current on-chain value, so the bare `update-params 100 20 3600 10 1800` above will not wipe them. Pass the flag with an empty value (e.g. `--reserved-domain-suffixes=""`) to explicitly clear the list.
 
 **Note:** There is no global `denom` parameter. Each SKU defines its own denomination in its `base_price`, enabling multi-denom billing.
 
@@ -133,8 +137,12 @@ Use `MsgCreateLeaseForTenant` to create leases on behalf of users:
 
 ```bash
 # Create a lease for a tenant
-# Format: sku-uuid:quantity
+# Format: sku-uuid:quantity[:service_name]
 manifestd tx billing create-lease-for-tenant [tenant-address] [sku-uuid:quantity...] --from [authority-key]
+
+# Optionally append :service_name (an RFC 1123 DNS label) for stack deployments. It is
+# all-or-nothing across the lease's items; in service-name mode the same SKU may appear
+# multiple times, and custom_domain can later be set per item via set-item-custom-domain.
 
 # Example: Create lease with 2 units of SKU 1 and 1 unit of SKU 2
 manifestd tx billing create-lease-for-tenant manifest1abc... 01912345-6789-7abc-8def-0123456789ab:2 01912345-6789-7abc-8def-0123456789ac:1 --from authority
@@ -204,9 +212,13 @@ for migration in "${MIGRATIONS[@]}"; do
   RESULT=$(manifestd tx billing create-lease-for-tenant "$tenant" $items \
     --from "$AUTHORITY_KEY" -y --gas auto --gas-adjustment 1.5 --output json)
   
-  LEASE_UUID=$(echo "$RESULT" | jq -r '.logs[0].events[] | select(.type=="lease_created") | .attributes[] | select(.key=="lease_uuid") | .value')
+  # In sync broadcast mode the tx response carries only code/txhash/raw_log and no
+  # events, so capture the txhash, wait a block, then query the tx for its events.
+  TXHASH=$(echo "$RESULT" | jq -r '.txhash')
   
   sleep 6  # Wait for block
+  
+  LEASE_UUID=$(manifestd query tx "$TXHASH" --output json | jq -r '.events[] | select(.type=="lease_created") | .attributes[] | select(.key=="lease_uuid") | .value')
   
   # Acknowledge lease (transitions to ACTIVE, billing starts)
   echo "  Acknowledging lease $LEASE_UUID..."
@@ -265,8 +277,8 @@ manifestd query tx [txhash] --output json | jq '.events'
 
 Key events:
 - `lease_created` - Contains `lease_uuid`, `tenant`, `provider_uuid`
-- `lease_acknowledged` - Contains `lease_uuid`, `provider_uuid`, `acknowledged_at`
-- `lease_rejected` - Contains `lease_uuid`, `provider_uuid`, `reason`
+- `lease_acknowledged` - Contains `lease_uuid`, `tenant`, `provider_uuid`, `acknowledged_by` (the ack timestamp comes from the `acknowledged_at` field of `MsgAcknowledgeLeaseResponse`, not the event)
+- `lease_rejected` - Contains `lease_uuid`, `tenant`, `provider_uuid`, `rejected_by`, `rejection_reason`
 - `lease_closed` - Contains `lease_uuid`, `tenant`, `settled_amounts`
 - `credit_funded` - Contains `tenant`, `amount`, `credit_address`
 
@@ -328,7 +340,7 @@ This happens if you try to create a lease before funding. The credit account is 
 manifestd tx billing fund-credit [tenant] [amount] --from authority
 ```
 
-### "SKU not found" or "SKU is not active"
+### "sku not found" or "sku not active"
 
 Ensure the SKU exists and is active:
 
@@ -360,7 +372,7 @@ manifestd query billing params
 
 To add your address to the allow list, the authority must update params.
 
-### "provider is not active"
+### "provider not active"
 
 The provider associated with the SKU has been deactivated. Contact the authority to reactivate, or use SKUs from an active provider.
 
@@ -382,7 +394,6 @@ Validates without blockchain context:
 - Lease UUIDs are valid and unique
 - Credit account addresses are correctly derived
 - Required fields are present
-- SKU-provider relationships are consistent
 
 ### Phase 2: Time-Based Validation (`ValidateWithBlockTime`)
 
@@ -392,10 +403,9 @@ Validates timestamps against block time during `InitGenesis`:
 |-------|------------|
 | `last_settled_at` | Must not be in the future |
 | `created_at` | Must not be in the future |
-| `closed_at` | Must not be in the future (for CLOSED leases) |
-| `rejected_at` | Must not be in the future (for REJECTED leases) |
-| `expired_at` | Must not be in the future (for EXPIRED leases) |
-| `acknowledged_at` | Must not be in the future (for ACTIVE leases) |
+| `closed_at` | Must not be in the future (for CLOSED leases with a non-nil `closed_at`) |
+
+**Note:** `rejected_at`, `expired_at`, and `acknowledged_at` are NOT time-validated at genesis, so a future-dated value in those fields will import silently.
 
 **Error Example:**
 ```
@@ -403,6 +413,15 @@ lease abc123 has last_settled_at (2025-01-08T00:00:00Z) in the future relative t
 ```
 
 **Resolution:** Ensure all timestamps in genesis state are at or before the genesis block time.
+
+### Phase 3: Cross-Module Validation (`InitGenesis`)
+
+During `InitGenesis`, the module additionally performs cross-module checks against the SKU module:
+- The lease's provider must exist (`skuKeeper.GetProvider`)
+- Every item's SKU must exist (`skuKeeper.GetSKU`)
+- Each SKU's `provider_uuid` must match the lease's `provider_uuid`
+
+These checks require the SKU module to be initialized first, which the genesis order (`sku -> billing`) guarantees.
 
 ## Related Documentation
 

--- a/x/billing/docs/TROUBLESHOOTING.md
+++ b/x/billing/docs/TROUBLESHOOTING.md
@@ -281,12 +281,12 @@ manifestd tx billing withdraw [lease-uuid] --from [provider-key]
 **Cause**: A provider-wide withdraw processes each lease in its own cached context; if a single lease fails, it is logged and skipped so the rest of the batch still succeeds. Two things determine what appears in the results:
 
 1. **Only ACTIVE leases are considered.** Provider-wide withdraw iterates the provider's ACTIVE leases only — CLOSED leases are already fully settled at close and never appear.
-2. **Per-lease errors are skipped, not fatal.** A lease is skipped when its settlement or store operation errors — for example a bank transfer failure, a missing or invalid provider payout address, a `last_settled_at` that is after the block time, or a zero withdrawable amount.
+2. **Leases are skipped for two different reasons.** A *normal* skip happens when the lease has nothing to settle — no elapsed time since the last settlement, or a zero withdrawable amount — and is silent and expected. An *error* skip happens when the lease's settlement or store operation fails — a bank transfer failure, a missing or invalid provider payout address, or a `last_settled_at` that is after the block time — in which case that lease's changes are discarded.
 
 **What happens**:
-1. The failing lease is skipped during the batch operation
-2. Other leases in the batch are processed normally
-3. No error is returned for the skipped lease (it is logged)
+1. The skipped lease is left unchanged; other leases in the batch are processed normally
+2. The overall transaction still succeeds
+3. No error is returned for a skipped lease — error skips are logged, normal (nothing-to-settle) skips are silent
 
 > **Arithmetic overflow does NOT skip the lease.** If a lease's accrued charge overflows (settlement duration beyond ~100 years, `MaxDurationSeconds`), the silent settlement path instead transfers the tenant's **entire remaining credit** in that lease's denoms to the provider and force-closes the lease. The funds are **not** preserved. Overflow is effectively unreachable in normal operation but can arise from a genesis import with an ancient `last_settled_at`.
 

--- a/x/billing/docs/TROUBLESHOOTING.md
+++ b/x/billing/docs/TROUBLESHOOTING.md
@@ -17,7 +17,7 @@ The credit account is created automatically when first funded.
 
 ### "insufficient credit balance"
 
-**Cause**: The credit account doesn't have enough balance in one or more denominations to cover the `min_lease_duration` requirement for the lease.
+**Cause**: The check is against *available* credit (available = balance − reserved_amounts), where reserved_amounts is the sum of reservations held by the tenant's existing PENDING and ACTIVE leases — not the raw balance. A tenant whose balance covers the `min_lease_duration` requirement can still hit this error if existing leases have that credit reserved. The full error text includes both balance and reserved, e.g. `insufficient available credit for denom <denom>: need <x>, have <y> available (balance: <b>, reserved: <r>)`. Check the `available_balances` field of `query billing credit-account` rather than the raw balance.
 
 **Solution**: 
 1. Check current balances:
@@ -157,7 +157,7 @@ manifestd tx billing create-lease 01912345-6789-7abc-8def-0123456789ab:1 --from 
 
 ## Lease Acknowledgement Issues
 
-### "lease not pending"
+### "lease not in pending state"
 
 **Cause**: Attempting to acknowledge, reject, or cancel a lease that is not in PENDING state.
 
@@ -170,7 +170,7 @@ Only PENDING leases can be acknowledged/rejected by providers or cancelled by te
 
 ### "unauthorized" (for acknowledge/reject)
 
-**Cause**: The sender is not the provider who owns the SKUs in the lease.
+**Cause**: The sender is neither the provider's management address for the SKUs in the lease nor the module authority. (Note: `allowed_list` does NOT grant acknowledge/reject — it only covers `CreateLeaseForTenant` and `SetItemCustomDomain`.)
 
 **Solution**: Use the correct provider key:
 ```bash
@@ -256,17 +256,6 @@ manifestd query billing lease [lease-uuid]
 3. For ACTIVE leases, wait for more time to pass for charges to accrue
 4. For closed leases, you cannot withdraw (settlement happened during close)
 
-### "lease not active"
-
-**Cause**: Attempting to withdraw from a lease that's not ACTIVE. PENDING leases don't accrue charges.
-
-**Solution**: 
-- For PENDING leases: Acknowledge the lease first
-- For CLOSED leases: Settlement happened during closure, nothing left to withdraw
-```bash
-manifestd query billing lease [lease-uuid]
-```
-
 ### "unauthorized"
 
 **Cause**: Only the provider (or authority) can withdraw from a lease.
@@ -289,25 +278,24 @@ manifestd tx billing withdraw [lease-uuid] --from [provider-key]
 
 ### Lease not included in provider-wide withdraw results
 
-**Cause**: During provider-wide withdraw batch operations, individual lease settlements that encounter arithmetic overflow (extremely long-running leases with high rates) are silently skipped to prevent the entire batch from failing.
+**Cause**: A provider-wide withdraw processes each lease in its own cached context; if a single lease fails, it is logged and skipped so the rest of the batch still succeeds. Two things determine what appears in the results:
+
+1. **Only ACTIVE leases are considered.** Provider-wide withdraw iterates the provider's ACTIVE leases only — CLOSED leases are already fully settled at close and never appear.
+2. **Per-lease errors are skipped, not fatal.** A lease is skipped when its settlement or store operation errors — for example a bank transfer failure, a missing or invalid provider payout address, a `last_settled_at` that is after the block time, or a zero withdrawable amount.
 
 **What happens**:
-1. The lease is skipped during the batch operation
+1. The failing lease is skipped during the batch operation
 2. Other leases in the batch are processed normally
-3. No error is returned for the skipped lease
-4. The skipped lease's funds remain available
+3. No error is returned for the skipped lease (it is logged)
+
+> **Arithmetic overflow does NOT skip the lease.** If a lease's accrued charge overflows (settlement duration beyond ~100 years, `MaxDurationSeconds`), the silent settlement path instead transfers the tenant's **entire remaining credit** in that lease's denoms to the provider and force-closes the lease. The funds are **not** preserved. Overflow is effectively unreachable in normal operation but can arise from a genesis import with an ancient `last_settled_at`.
 
 **Solution**:
 1. Use specific lease withdrawal for the problematic lease to see the actual error:
    ```bash
    manifestd tx billing withdraw [lease-uuid] --from provider
    ```
-2. If overflow is the issue, close the lease and create a new one:
-   ```bash
-   manifestd tx billing close-lease [lease-uuid] --from provider
-   ```
-
-**Note**: This scenario only occurs with extremely long-running leases (years) with high per-second rates. Normal usage will not encounter this issue.
+2. Verify the provider's payout address is set and valid (`manifestd query sku provider [provider-uuid]`), then retry.
 
 ---
 
@@ -338,6 +326,18 @@ manifestd tx billing withdraw [lease-uuid] --from [key]
 # Mode 2: Provider-wide
 manifestd tx billing withdraw --provider [provider-uuid] --from [key]
 ```
+
+### "key (pagination cursor) is only valid in provider-wide mode"
+
+**Cause**: `--key` was passed together with positional lease UUIDs. The cursor is only meaningful in provider-wide mode.
+
+**Solution**: Drop `--key`, or drop the lease UUIDs and use provider-wide mode.
+
+### "key length N exceeds maximum 64"
+
+**Cause**: The `--key` value is not a `next_key` from a prior response. The cursor is a lease UUID (36 bytes) and is bounded by `MaxWithdrawCursorLen` (64).
+
+**Solution**: Pass the base64 `next_key` from the previous response verbatim.
 
 ### Response shows "has_more: true"
 
@@ -391,9 +391,9 @@ manifestd query billing lease uuid3  # PENDING - ok
 manifestd tx billing acknowledge-lease uuid1 uuid3 --from provider  # SUCCESS
 ```
 
-### "too many lease items in batch"
+### "too many leases: N exceeds maximum 100"
 
-**Cause**: Exceeding `MaxBatchLeaseSize` (100 leases) in a single batch operation.
+**Cause**: Exceeding `MaxBatchLeaseSize` (100 leases) in a single batch operation. This is returned as `ErrInvalidLease` by `ValidateBatchLeaseUUIDs`.
 
 **Solution**: Split into multiple smaller batches:
 ```bash
@@ -417,7 +417,7 @@ manifestd query tx [txhash] --output json | jq '.events[] | select(.type | start
 
 **Event pattern:**
 - Individual operations: `lease_acknowledged`, `lease_rejected`, etc. (one per lease)
-- Batch summary: `batch_acknowledged`, `batch_rejected`, etc. (one per transaction)
+- Batch summary: `batch_acknowledged`, `batch_rejected`, etc. (one per transaction, emitted only when the batch contains more than one lease — a single-lease call emits only the individual event). Exception: provider-wide withdraw always emits `batch_withdraw`, even when nothing was withdrawn.
 
 ---
 
@@ -452,7 +452,7 @@ Pending leases expire automatically if providers don't acknowledge them within `
 2. Checks pending leases against `created_at + pending_timeout`
 3. Expired leases transition to EXPIRED state
 4. Credit is unlocked (was never billed since lease was never active)
-5. `LeaseExpired` event is emitted
+5. `lease_expired` event is emitted (attributes: lease_uuid, tenant, provider_uuid, reason="pending_timeout")
 
 **Rate limiting**: Max 100 expirations per block to prevent DoS.
 
@@ -472,7 +472,7 @@ Pending leases expire automatically if providers don't acknowledge them within `
 
 ### Understanding Auto-Close
 
-Auto-close is triggered when an ACTIVE lease's credit is exhausted (balance = 0). It happens during write operations only:
+Auto-close is triggered when an ACTIVE lease's projected accrual meets or exceeds the credit balance for any denom the lease bills in (accrued >= balance) — the balance does not have to reach exactly zero. When no time has elapsed since the last settlement, a zero balance in any lease denom triggers it. It happens during write operations only:
 - `Withdraw` - If credit exhausted after settlement
 - `CloseLease` - If credit was already exhausted
 
@@ -497,8 +497,10 @@ manifestd query billing lease [lease-uuid]
 manifestd query tx [txhash] --output json | jq '.events'
 ```
 
-Events to look for:
-- `lease_closed`
+Events to look for (the event depends on which write path triggered the auto-close):
+- `lease_closed` with `closed_by="credit_exhaustion"` (auto-close via `CloseLease`)
+- `provider_withdraw` with `auto_closed="true"` (auto-close via specific-lease `Withdraw`)
+- `lease_auto_closed` with `reason="credit_exhausted"` (auto-close via provider-wide `Withdraw`)
 
 **Resolution**: 
 1. Fund the credit account again
@@ -517,9 +519,14 @@ Events to look for:
   # Get real-time withdrawable for a specific lease
   manifestd query billing withdrawable [lease-uuid]
   
-  # Get real-time total withdrawable for a provider
+  # Get real-time withdrawable for a provider's ACTIVE leases, one page at a time
   manifestd query billing provider-withdrawable [provider-uuid]
   ```
+  A single `provider-withdrawable` response is a partial, per-page total over the
+  provider's ACTIVE leases (page size default 100, max 1000). Loop, passing
+  `pagination.next_key` back as `--page-key`, and sum the per-page `amounts` until
+  `next_key` is empty. This query no longer has a `has_more` field — branch on
+  `len(pagination.next_key) > 0`.
 
 ## Parameter Issues
 
@@ -528,11 +535,12 @@ Events to look for:
 **Cause**: Invalid parameter values in UpdateParams.
 
 **Common issues**:
-- `min_lease_duration` must be > 0
-- `max_leases_per_tenant` must be > 0
+- `min_lease_duration` must be > 0 and ≤ 2592000 (30 days)
+- `max_leases_per_tenant` must be > 0 and ≤ 10000
 - `max_items_per_lease` must be > 0 and ≤ 100
-- `max_pending_leases_per_tenant` must be > 0
+- `max_pending_leases_per_tenant` must be > 0 and ≤ 1000
 - `pending_timeout` must be between 60 (1 min) and 86400 (24 hours)
+- `reserved_domain_suffixes`: each entry must start with '.', the part after the dot must be a valid FQDN, and duplicates are rejected
 
 **Solution**: Check current params and ensure new values are valid:
 ```bash
@@ -556,9 +564,9 @@ manifestd tx billing update-params ... --from authority
 
 **Solution**: Increase gas limit:
 ```bash
-manifestd tx billing create-lease 1:10 --from tenant --gas 500000
+manifestd tx billing create-lease 01912345-6789-7abc-8def-0123456789ab:10 --from tenant --gas 500000
 # Or use auto
-manifestd tx billing create-lease 1:10 --from tenant --gas auto --gas-adjustment 1.5
+manifestd tx billing create-lease 01912345-6789-7abc-8def-0123456789ab:10 --from tenant --gas auto --gas-adjustment 1.5
 ```
 
 ### Transaction pending/not included

--- a/x/sku/README.md
+++ b/x/sku/README.md
@@ -19,7 +19,7 @@ A Provider represents an entity that offers services. Each Provider contains:
 - **Meta Hash**: A hash of off-chain metadata for extended information
 - **Active**: Whether the provider is currently active
 
-Providers can be deactivated (soft delete), which prevents creating new SKUs for that provider but allows existing SKUs and leases to continue operating.
+Providers can be deactivated (soft delete). Deactivation cascades to deactivate all of the provider's SKUs and blocks new SKUs and new leases; existing leases continue operating at their locked-in prices.
 
 ### SKU
 
@@ -76,9 +76,9 @@ Provider and SKU operations (create, update, deactivate) can be performed by:
 
 Only the module authority can update the parameters (including the allowed list).
 
-**Management Address Permissions:** The Provider's `Address` field (management address) grants authorization for **billing operations only** (acknowledge/reject leases, withdraw earnings). It does **not** grant permission to modify provider or SKU records—those operations require authority or `allowed_list` membership.
+**Management Address Permissions:** The Provider's `Address` field (management address) grants authorization for **billing operations only** (acknowledge/reject leases, close leases, withdraw earnings). It does **not** grant permission to modify provider or SKU records—those operations require authority or `allowed_list` membership.
 
-**Transferability:** Providers and SKUs can be transferred to a new management address via `UpdateProvider` or `UpdateSKU`, but only by the authority or `allowed_list` members—not by the current management address holder. Upon transfer, the new address gains billing operation rights.
+**Transferability:** A Provider's management address can be changed via `UpdateProvider`, but only by the authority or `allowed_list` members—not by the current management address holder. Upon transfer, the new address gains billing operation rights. SKUs have no management address and cannot be re-parented—`UpdateSKU` rejects a `provider_uuid` that differs from the stored one (`ErrInvalidSKU` "provider_uuid mismatch").
 
 ### Validation Constants
 
@@ -87,6 +87,8 @@ Only the module authority can update the parameters (including the allowed list)
 | `MaxSKUNameLength` | 256 | Maximum length of SKU name in characters |
 | `MaxAPIURLLength` | 2048 | Maximum length of provider API URL in characters |
 | `MaxMetaHashLength` | 64 | Maximum length of meta_hash field in bytes (accommodates SHA-512) |
+| `DefaultDeactivateSKULimit` | 50 | SKUs deactivated per `DeactivateProvider` call when `limit` is unset (0) |
+| `MaxDeactivateSKULimit` | 100 | Maximum SKUs deactivatable in a single `DeactivateProvider` call |
 
 **API URL Requirements:**
 - Must use HTTPS scheme (http:// is rejected)
@@ -110,7 +112,7 @@ Only the module authority can update the parameters (including the allowed list)
 
 - SKUs can only be created for active Providers
 - SKU base price must be exactly divisible by the billing unit's seconds (no rounding)
-- Deactivating a Provider **cascades to deactivate all its SKUs** (one-way cascade)
+- Deactivating a Provider **cascades to deactivate all its SKUs** (one-way cascade). The cascade is paginated: one call deactivates at most `limit` SKUs (default `DefaultDeactivateSKULimit` = 50, max `MaxDeactivateSKULimit` = 100), the provider is marked inactive on the first call only, and the caller must repeat `deactivate-provider` while the response's `has_more` is true. A provider with more SKUs than `limit` is only partially cascaded by a single call, transiently leaving active SKUs under an inactive provider.
 - Deactivating a SKU is a soft delete - the SKU remains queryable but cannot be used for new leases
 - Provider and SKU UUIDs are generated deterministically using UUIDv7 format and never reused
 
@@ -210,8 +212,12 @@ message GenesisState {
   Params params = 1;
   repeated Provider providers = 2;
   repeated SKU skus = 3;
+  uint64 provider_sequence = 4;
+  uint64 sku_sequence = 5;
 }
 ```
+
+`provider_sequence` and `sku_sequence` are the deterministic-UUID sequence counters. They are exported via `Sequence.Peek()` and must be **>= the number of exported providers/skus** respectively, otherwise genesis validation fails and the chain will not start.
 
 Example genesis configuration:
 
@@ -244,7 +250,9 @@ Example genesis configuration:
         "meta_hash": "",
         "active": true
       }
-    ]
+    ],
+    "provider_sequence": "1",
+    "sku_sequence": "1"
   }
 }
 ```
@@ -254,6 +262,7 @@ Example genesis configuration:
 - Each SKU must reference an existing provider UUID from the same genesis state
 - Provider API URLs are validated if provided (must be HTTPS, no credentials)
 - No duplicate provider or SKU UUIDs allowed
+- `provider_sequence` must be >= `len(providers)` and `sku_sequence` >= `len(skus)` (omitted counters default to 0, which fails validation when any provider/sku is listed)
 
 ## Client
 
@@ -276,6 +285,7 @@ manifestd query sku skus-by-provider [provider-uuid]
 - [Provider Setup Guide](docs/PROVIDER_GUIDE.md) - Step-by-step guide to creating providers
 - [SKU Setup Guide](docs/SKU_GUIDE.md) - Step-by-step guide to creating SKUs
 - [API Reference](docs/API.md) - Complete CLI and gRPC/REST API reference
+- [Frontend & Signing Guide](../../docs/FRONTEND.md) - Building frontends and signing transactions
 - [Troubleshooting](docs/TROUBLESHOOTING.md) - Common errors and solutions
 
 ### Developer Documentation

--- a/x/sku/docs/API.md
+++ b/x/sku/docs/API.md
@@ -146,9 +146,9 @@ manifestd tx sku create-sku 01912345-6789-7abc-8def-0123456789ab "Compute Instan
 
 The base price must be exactly divisible by the billing unit's seconds. See [Pricing and Exact Divisibility](../README.md#pricing-and-exact-divisibility) for requirements and examples.
 
-**Error Messages:**
-- If price is not divisible: `invalid sku: price X is not evenly divisible by unit seconds Y`
-- If price results in zero per-second rate: `invalid sku: price per second would be zero`
+**Error Messages** (produced under `ErrInvalidSKU`, wrapped as `invalid create sku message: invalid price/unit combination: ...`; the unit renders as its enum name, e.g. `UNIT_PER_HOUR`):
+- If price is not evenly divisible: `base price <price> is not evenly divisible by <UNIT_NAME> (remainder: <r>); price must be exactly divisible to avoid rounding errors`
+- If price results in a zero per-second rate: `base price <price> with unit <UNIT_NAME> results in zero per-second rate; increase price or change unit`
 
 ---
 
@@ -233,6 +233,8 @@ manifestd tx sku update-params \
 ---
 
 ### Query Commands
+
+**Pagination note:** For the index-backed queries below (`provider-by-address`, `providers`, `skus`, `skus-by-provider`), cursor resume is deletion-tolerant — a `--page-key` whose row was removed between calls resumes from the next surviving entry rather than returning an empty page — and `--reverse` may be combined with `--page-key`. The `next_key` value is unchanged on the wire, so existing paging clients need no change.
 
 #### params
 
@@ -1009,4 +1011,6 @@ manifestd query tx [txhash] --output json | jq -r '.logs[0].events[] | select(.t
 - [SKU Setup Guide](SKU_GUIDE.md) - Step-by-step guide to creating SKUs
 - [Architecture](ARCHITECTURE.md) - Internal architecture and data models
 - [Design Decisions](DESIGN_DECISIONS.md) - Key design decisions and rationale
+- [Capabilities](CAPABILITIES.md) - Module capability overview
+- [Troubleshooting](TROUBLESHOOTING.md) - Common errors and resolutions
 - [Billing Module](../../billing/README.md) - Understanding the billing system

--- a/x/sku/docs/ARCHITECTURE.md
+++ b/x/sku/docs/ARCHITECTURE.md
@@ -11,16 +11,14 @@ The SKU (Stock Keeping Unit) module provides on-chain management of service offe
 ```mermaid
 graph TD
     SKU[x/sku Module]
-    POA[x/poa Module]
     Billing[x/billing Module]
-    
-    SKU -->|authority validation| POA
+
     Billing -->|SKU lookups| SKU
     Billing -->|Provider lookups| SKU
 ```
 
 The SKU module:
-- **Depends on**: `x/poa` for authority validation
+- **Authority**: holds the PoA admin address as its `authority` string (injected in `app.go` via `helpers.GetPoAAdmin()`); it makes no calls into `x/poa`. Authorization is a string compare against that address plus `Params.AllowedList`.
 - **Depended on by**: `x/billing` for SKU and Provider information
 
 ## Data Model
@@ -97,7 +95,7 @@ The SKU module supports configurable parameters to control access and behavior:
 - All addresses in `AllowedList` must be valid bech32 addresses.
 - No duplicate addresses are allowed.
 
-Parameters can be updated via governance or authorized messages, and changes are emitted as `params_updated` events.
+Parameters can be updated only via `MsgUpdateParams` from the POA authority (allow-listed addresses cannot modify params), and changes are emitted as `params_updated` events.
 
 ## Storage Layout
 
@@ -173,17 +171,15 @@ sequenceDiagram
     participant User
     participant MsgServer
     participant Keeper
-    participant POA
     participant Store
-    
+
     User->>MsgServer: MsgCreateProvider
-    MsgServer->>MsgServer: ValidateBasic()
-    MsgServer->>POA: Check Authority
-    alt Not Authority
-        POA-->>MsgServer: Unauthorized
-        MsgServer-->>User: Error
-    else Is Authority
-        POA-->>MsgServer: OK
+    MsgServer->>MsgServer: isAuthorizedSender() (GetAuthority string compare + AllowedList params lookup)
+    alt Not authority AND not in AllowedList
+        MsgServer-->>User: Unauthorized
+    else Authorized
+        MsgServer->>MsgServer: Validate()
+        Note over MsgServer: Unauthorized senders never reach validation
         MsgServer->>Keeper: CreateProvider()
         Keeper->>Store: Get Next ID
         Store-->>Keeper: ID
@@ -201,18 +197,15 @@ sequenceDiagram
     participant User
     participant MsgServer
     participant Keeper
-    participant POA
     participant Store
-    
+
     User->>MsgServer: MsgCreateSKU
-    MsgServer->>MsgServer: ValidateBasic()
-    Note over MsgServer: Validates price divisibility
-    MsgServer->>POA: Check Authority
-    alt Not Authority
-        POA-->>MsgServer: Unauthorized
-        MsgServer-->>User: Error
-    else Is Authority
-        POA-->>MsgServer: OK
+    MsgServer->>MsgServer: isAuthorizedSender() (GetAuthority string compare + AllowedList params lookup)
+    alt Not authority AND not in AllowedList
+        MsgServer-->>User: Unauthorized
+    else Authorized
+        MsgServer->>MsgServer: Validate()
+        Note over MsgServer: Validates price divisibility; unauthorized senders never reach validation
         MsgServer->>Keeper: GetProvider()
         alt Provider Not Found or Inactive
             Keeper-->>MsgServer: Error
@@ -237,31 +230,44 @@ sequenceDiagram
     participant User
     participant MsgServer
     participant Keeper
-    participant POA
     participant Store
-    
+
     User->>MsgServer: MsgUpdateSKU
-    MsgServer->>MsgServer: ValidateBasic()
-    MsgServer->>POA: Check Authority
-    MsgServer->>Keeper: GetSKU()
-    alt SKU Not Found
-        Keeper-->>MsgServer: Error
-        MsgServer-->>User: Error
-    else SKU Found
-        Keeper-->>MsgServer: Existing SKU
-        alt Provider Changed
-            MsgServer->>Keeper: GetProvider(new)
-            alt Provider Invalid
+    MsgServer->>MsgServer: isAuthorizedSender() (GetAuthority string compare + AllowedList params lookup)
+    alt Not authority AND not in AllowedList
+        MsgServer-->>User: Unauthorized
+    else Authorized
+        MsgServer->>MsgServer: Validate()
+        Note over MsgServer: Unauthorized senders never reach validation
+        MsgServer->>Keeper: GetSKU()
+        alt SKU Not Found
+            Keeper-->>MsgServer: Error
+            MsgServer-->>User: Error
+        else SKU Found
+            Keeper-->>MsgServer: Existing SKU
+            alt provider_uuid != existingSKU.provider_uuid
+                MsgServer-->>User: ErrInvalidSKU (provider_uuid mismatch)
+            end
+            MsgServer->>Keeper: GetProvider(existingSKU.provider_uuid)
+            alt Provider Not Found
                 Keeper-->>MsgServer: Error
                 MsgServer-->>User: Error
             end
-            MsgServer->>Store: Remove Old Index
-            MsgServer->>Store: Add New Index
+            alt active -> inactive
+                MsgServer-->>User: ErrInvalidSKU (use DeactivateSKU instead)
+            end
+            alt reactivation while provider inactive
+                MsgServer-->>User: ErrInvalidProvider
+            end
+            MsgServer->>Keeper: SetSKU()
+            Keeper->>Store: Save SKU
+            Note over MsgServer: IndexedMap maintains indexes implicitly
+            alt inactive -> active
+                MsgServer->>MsgServer: Emit sku_activated
+            end
+            MsgServer->>MsgServer: Emit sku_updated
+            MsgServer-->>User: Success
         end
-        MsgServer->>Keeper: UpdateSKU()
-        Keeper->>Store: Save SKU
-        MsgServer->>MsgServer: Emit Event
-        MsgServer-->>User: Success
     end
 ```
 
@@ -271,26 +277,47 @@ sequenceDiagram
 
 SKU prices must be evenly divisible by their unit's seconds to ensure exact per-second rate calculations. See [Pricing and Exact Divisibility](../README.md#pricing-and-exact-divisibility) for the user-facing explanation.
 
-**Implementation:**
+**Implementation** (`x/sku/types/unit.go`):
 ```go
-func ValidatePriceDivisibility(unit Unit, price sdk.Coin) error {
-    seconds := unit.Seconds()
-    if seconds == 0 {
-        return ErrInvalidUnit
+func ValidatePriceAndUnit(basePrice sdk.Coin, unit Unit) error {
+    divisor, ok := divisorForUnit(unit)
+    if !ok {
+        return fmt.Errorf("invalid unit: %s", unit)
     }
-    remainder := price.Amount.Mod(math.NewInt(seconds))
+
+    perSecond := basePrice.Amount.Quo(divisor)
+
+    // Check if per-second rate is zero (would result in free usage)
+    if perSecond.IsZero() {
+        return &PriceValidationError{
+            BasePrice: basePrice,
+            Unit:      unit,
+            IsZero:    true,
+        }
+    }
+
+    // Check if division is exact (no remainder)
+    remainder := basePrice.Amount.Mod(divisor)
     if !remainder.IsZero() {
-        return ErrPriceNotDivisible
+        return &PriceValidationError{
+            BasePrice: basePrice,
+            Unit:      unit,
+            IsZero:    false,
+            Remainder: remainder,
+        }
     }
+
     return nil
 }
 ```
+
+The divisor comes from the unexported `divisorForUnit(unit)` (3600 for `UNIT_PER_HOUR`, 86400 for `UNIT_PER_DAY`). On failure the function returns a `*PriceValidationError` with two modes: `IsZero=true` ("results in zero per-second rate") when the price truncates to a zero rate, and `IsZero=false` ("not evenly divisible ... remainder: %s") when division leaves a remainder.
 
 ### Provider State Validation
 
 - Cannot create SKU for non-existent provider
 - Cannot create SKU for inactive provider
-- Can update SKU to reference different active provider
+- A SKU cannot be re-parented — `MsgUpdateSKU.provider_uuid` must equal the SKU's existing `provider_uuid`, else `ErrInvalidSKU: provider_uuid mismatch`
 - Deactivating provider cascades to deactivate all its SKUs (paginated for gas safety)
 
 ## Events and Error Codes
@@ -301,10 +328,12 @@ For the complete reference of events and error codes, see [API Reference](API.md
 
 ### Authorization Model
 
-All write operations require either POA authority or user inclusion in the `AllowedList`:
+Most write operations require either POA authority or user inclusion in the `AllowedList`:
 - Only the POA admin group or users in the `AllowedList` can create/update providers
 - Only the POA admin group or users in the `AllowedList` can create/update SKUs
 - No other user-level SKU management is permitted
+
+**Exception:** `MsgUpdateParams` is authority-only — allow-listed addresses cannot modify params (they cannot add themselves or others to the `AllowedList`). Only the six provider/SKU write handlers accept allow-listed senders.
 
 The `AllowedList` is a configurable list of user addresses permitted to perform write operations alongside the POA authority.
 
@@ -351,8 +380,10 @@ The following optimizations have been identified but deferred due to marginal be
 
 ### Unit Tests
 - Message validation (`msgs_test.go`)
-- Type methods (`types_test.go`)
-- Keeper operations (`keeper_test.go`)
+- Unit/pricing logic (`unit_test.go`)
+- Params validation (`params_test.go`)
+- Genesis validation (`genesis_test.go`)
+- Keeper operations (`keeper_test.go`, `msg_server_test.go`, `querier_test.go`)
 
 ### Integration Tests
 - Genesis import/export
@@ -370,3 +401,13 @@ The following optimizations have been identified but deferred due to marginal be
 - Random provider creation
 - Random SKU creation/updates
 - Weight-based operation distribution
+
+## Related Documentation
+
+- [SKU Module README](../README.md) - Module overview
+- [API Reference](API.md) - Messages, queries, events, and error codes
+- [Design Decisions](DESIGN_DECISIONS.md) - Key design decisions and rationale
+- [Provider Setup Guide](PROVIDER_GUIDE.md) - Step-by-step guide to creating providers
+- [SKU Setup Guide](SKU_GUIDE.md) - Step-by-step guide to creating SKUs
+- [Troubleshooting](TROUBLESHOOTING.md) - Common issues and resolutions
+- [Billing Module](../../billing/docs/ARCHITECTURE.md) - Downstream consumer of SKU/Provider data

--- a/x/sku/docs/DESIGN_DECISIONS.md
+++ b/x/sku/docs/DESIGN_DECISIONS.md
@@ -93,7 +93,7 @@ This separation exists because:
 
 ## Decision 4: Authority-Only Access with AllowedList
 
-**Decision:** All write operations require either POA authority or user inclusion in the `allowed_list` parameter.
+**Decision:** All provider/SKU write operations (Create/Update/Deactivate for both Provider and SKU) require either POA authority or `allowed_list` membership. `MsgUpdateParams` is the exception—it is authority-only, so allow-listed addresses cannot modify the allowed list itself.
 
 **Alternatives Considered:**
 1. Provider self-registration
@@ -115,18 +115,20 @@ This separation exists because:
 
 The Provider's `Address` field (management address) grants **limited** authorization for billing operations, but **not** for SKU module operations:
 
-| Operation | Management Address | Authority/AllowedList |
-|-----------|-------------------|----------------------|
-| Acknowledge leases | ✓ | ✓ |
-| Reject leases | ✓ | ✓ |
-| Withdraw earnings | ✓ | ✓ |
-| Close leases (as provider) | ✓ | ✓ |
-| Create/Update/Deactivate Provider | ✗ | ✓ |
-| Create/Update/Deactivate SKU | ✗ | ✓ |
-| Transfer Provider to new address | ✗ | ✓ |
+| Operation | Management Address | Authority | AllowedList |
+|-----------|-------------------|-----------|-------------|
+| Acknowledge leases | ✓ | ✓ | ✗ |
+| Reject leases | ✓ | ✓ | ✗ |
+| Withdraw earnings | ✓ | ✓ | ✗ |
+| Close leases (as provider) | ✓ | ✓ | ✗ |
+| Create/Update/Deactivate Provider | ✗ | ✓ | ✓ |
+| Create/Update/Deactivate SKU | ✗ | ✓ | ✓ |
+| Transfer Provider to new address | ✗ | ✓ | ✓ |
+
+> **Note:** x/sku's `allowed_list` confers no rights in x/billing at all. The billing operations above (acknowledge, reject, withdraw, close) are gated only on the provider's management address or the module authority. x/billing has its own separate `allowed_list`, which grants only `CreateLeaseForTenant` and `SetItemCustomDomain`—not the operations in this table.
 
 **Transferability:**
-- Providers and SKUs **are transferable** via `UpdateProvider` and `UpdateSKU`
+- Provider management and payout addresses **are transferable** via `UpdateProvider`. SKUs are not transferable—`UpdateSKU` rejects any change to `provider_uuid` with `ErrInvalidSKU` ("provider_uuid mismatch"); a SKU's owner changes only implicitly when its provider's address changes.
 - Transfer requires authority or `allowed_list` membership
 - The current management address holder **cannot** transfer to another address themselves
 - To transfer a provider: an authorized party calls `UpdateProvider` with the new `Address`
@@ -154,10 +156,7 @@ This model separates operational control (billing) from administrative control (
 - Must use specific price values (multiples of 3600 for hourly, 86400 for daily)
 - Harder to express "nice" prices
 
-**Implementation:** The billing module calculates per-second rate as:
-```go
-ratePerSecond = basePrice.Amount / unit.Seconds()
-```
+**Implementation:** The rate is computed by `skutypes.CalculatePricePerSecond(basePrice, unit)` (x/sku/types/unit.go), which divides `basePrice.Amount` by 3600 (`UNIT_PER_HOUR`) or 86400 (`UNIT_PER_DAY`) and fails if the result is zero or the division leaves a remainder. x/billing wraps it as `ConvertBasePriceToPerSecond` at lease creation.
 
 ## Decision 6: Unit Enum vs Seconds Storage
 

--- a/x/sku/docs/PROVIDER_GUIDE.md
+++ b/x/sku/docs/PROVIDER_GUIDE.md
@@ -123,7 +123,8 @@ manifestd tx sku create-provider \
       "attributes": [
         {"key": "provider_uuid", "value": "01912345-6789-7abc-8def-0123456789ab"},
         {"key": "address", "value": "manifest1provideraddr..."},
-        {"key": "payout_address", "value": "manifest1payoutaddr..."}
+        {"key": "payout_address", "value": "manifest1payoutaddr..."},
+        {"key": "created_by", "value": "manifest1authority..."}
       ]
     }
   ]
@@ -149,11 +150,13 @@ Response:
     "address": "manifest1provideraddr...",
     "payout_address": "manifest1payoutaddr...",
     "api_url": "https://api.myprovider.com",
-    "meta_hash": "oLLD1OX2",
+    "meta_hash": "obLD1OX2",
     "active": true
   }
 }
 ```
+
+> **Note:** `meta_hash` is a `bytes` field, so it is returned base64-encoded in JSON output even though it is supplied as hex on the CLI (`a1b2c3d4e5f6` becomes `obLD1OX2`).
 
 List all providers:
 ```bash
@@ -181,6 +184,10 @@ manifestd tx sku update-provider \
   --chain-id manifest-1
 ```
 
+> **Important:** `update-provider` is a full overwrite, not a partial update. Every field — `address`, `payout_address`, `meta_hash`, and `active` — must be re-supplied. Omitting `--meta-hash` clears the existing meta_hash; only `--api-url` is preserved when left empty.
+>
+> The `<active>` argument accepts `true` only — it keeps the provider active or reactivates an inactive one. Passing `false` on an active provider fails with `cannot deactivate provider via UpdateProvider; use DeactivateProvider instead`; use `deactivate-provider` (Step 6) instead, which cascades to SKUs.
+
 ### Example: Change Payout Address
 
 ```bash
@@ -190,6 +197,7 @@ manifestd tx sku update-provider \
   manifest1newpayoutaddr111222333 \
   true \
   --api-url https://api.myprovider.com \
+  --meta-hash a1b2c3d4e5f6 \
   --from mykey \
   --chain-id manifest-1
 ```
@@ -200,12 +208,13 @@ To deactivate a provider (soft delete):
 
 ```bash
 manifestd tx sku deactivate-provider 01912345-6789-7abc-8def-0123456789ab \
+  --limit 50 \
   --from mykey \
   --chain-id manifest-1
 ```
 
 > **Important:** Deactivating a provider:
-> - **Cascades to deactivate ALL SKUs** under this provider automatically
+> - **Cascades to deactivate the provider's SKUs, up to `--limit` per call** (default 50, max 100). If `has_more` is `true` in the response, run the command again with the same UUID to continue; the provider itself is deactivated on the first call only.
 > - Prevents creation of new SKUs for this provider
 > - Does NOT affect existing leases (billing continues at locked prices)
 > - The provider can still receive withdrawals from active leases
@@ -244,7 +253,7 @@ Once your provider is created, you can:
 
 **Solution:**
 - Ensure addresses start with `manifest1`
-- Verify the address is the correct length (typically 43 characters for bech32)
+- Verify the address is the correct length (typically 47 characters for a `manifest`-prefixed account address)
 
 ## Provider Lifecycle
 
@@ -263,8 +272,9 @@ Once your provider is created, you can:
 │                  new SKUs           new SKUs                    │
 │                       │                  │                      │
 │                       v                  v                      │
-│                  SKUs active       ALL SKUs cascade             │
-│                                    to INACTIVE                  │
+│                  SKUs active       SKUs cascade to INACTIVE     │
+│                                    (paginated; repeat while     │
+│                                     has_more)                   │
 │                       │                  │                      │
 │                       v                  v                      │
 │                  Existing leases   Existing leases              │

--- a/x/sku/docs/PROVIDER_GUIDE.md
+++ b/x/sku/docs/PROVIDER_GUIDE.md
@@ -186,7 +186,7 @@ manifestd tx sku update-provider \
 
 > **Important:** `update-provider` is a full overwrite, not a partial update. Every field — `address`, `payout_address`, `meta_hash`, and `active` — must be re-supplied. Omitting `--meta-hash` clears the existing meta_hash; only `--api-url` is preserved when left empty.
 >
-> The `<active>` argument accepts `true` only — it keeps the provider active or reactivates an inactive one. Passing `false` on an active provider fails with `cannot deactivate provider via UpdateProvider; use DeactivateProvider instead`; use `deactivate-provider` (Step 6) instead, which cascades to SKUs.
+> The `<active>` argument cannot be used to deactivate a currently-active provider: passing `false` on an active provider fails with `cannot deactivate provider via UpdateProvider; use DeactivateProvider instead` — use `deactivate-provider` (Step 6) instead, which cascades to SKUs. Pass `true` to keep the provider active or to reactivate an inactive one. (An already-inactive provider also accepts `false`, leaving it inactive.)
 
 ### Example: Change Payout Address
 

--- a/x/sku/docs/SKU_GUIDE.md
+++ b/x/sku/docs/SKU_GUIDE.md
@@ -106,7 +106,7 @@ manifestd tx sku create-sku \
   "Storage Basic" \
   2 \
   86400upwr \
-  --meta-hash e5f6g7h8 \
+  --meta-hash e5f6a7b8 \
   --from mykey \
   --chain-id manifest-1 \
   --fees 5000upwr
@@ -124,7 +124,9 @@ manifestd tx sku create-sku \
       "attributes": [
         {"key": "sku_uuid", "value": "01912345-6789-7abc-8def-0123456789cd"},
         {"key": "provider_uuid", "value": "01912345-6789-7abc-8def-0123456789ab"},
-        {"key": "name", "value": "Compute Small"}
+        {"key": "name", "value": "Compute Small"},
+        {"key": "base_price", "value": "3600upwr"},
+        {"key": "created_by", "value": "manifest1..."}
       ]
     }
   ]
@@ -153,7 +155,7 @@ Response:
       "denom": "upwr",
       "amount": "3600"
     },
-    "meta_hash": "oLLD1A==",
+    "meta_hash": "obLD1A==",
     "active": true
   }
 }
@@ -186,6 +188,10 @@ manifestd tx sku update-sku \
   --chain-id manifest-1
 ```
 
+> **Important:** `update-sku` is a FULL OVERWRITE - it replaces every field from the request. Omitting `--meta-hash` sends an empty hash and silently CLEARS the stored `meta_hash`, so re-pass the current `--meta-hash` on every update that should keep it.
+>
+> The `<active>` argument must be `true`. Passing `false` for an active SKU is rejected ("cannot deactivate SKU via UpdateSKU; use DeactivateSKU instead") - use `deactivate-sku` instead. Reactivating an inactive SKU (`active=true`) additionally requires the provider to be active.
+
 ### Example: Update Price
 
 ```bash
@@ -196,6 +202,7 @@ manifestd tx sku update-sku \
   1 \
   7200upwr \
   true \
+  --meta-hash a1b2c3d4 \
   --from mykey \
   --chain-id manifest-1
 ```
@@ -219,7 +226,7 @@ manifestd tx sku deactivate-sku 01912345-6789-7abc-8def-0123456789cd \
 > - Can be reactivated later via `update-sku` with `active=true`
 > - The provider must also be active for the SKU to be usable in new leases
 >
-> **Note:** Deactivating a **provider** automatically cascades to deactivate ALL its SKUs. See [Provider Guide](PROVIDER_GUIDE.md#step-6-deactivate-provider-if-needed) for details.
+> **Note:** Deactivating a **provider** cascades to deactivate its SKUs, but the cascade is paginated. Each `deactivate-provider` call deactivates up to `--limit` SKUs (default 50, max 100) and returns `has_more`; repeat the call while `has_more: true` to deactivate the remaining SKUs. See [Provider Guide](PROVIDER_GUIDE.md#step-6-deactivate-provider-if-needed) for details.
 
 ## Creating Multiple SKUs
 

--- a/x/sku/docs/SKU_GUIDE.md
+++ b/x/sku/docs/SKU_GUIDE.md
@@ -190,7 +190,7 @@ manifestd tx sku update-sku \
 
 > **Important:** `update-sku` is a FULL OVERWRITE - it replaces every field from the request. Omitting `--meta-hash` sends an empty hash and silently CLEARS the stored `meta_hash`, so re-pass the current `--meta-hash` on every update that should keep it.
 >
-> The `<active>` argument must be `true`. Passing `false` for an active SKU is rejected ("cannot deactivate SKU via UpdateSKU; use DeactivateSKU instead") - use `deactivate-sku` instead. Reactivating an inactive SKU (`active=true`) additionally requires the provider to be active.
+> The `<active>` argument cannot be used to deactivate a currently-active SKU: passing `false` for an active SKU is rejected ("cannot deactivate SKU via UpdateSKU; use DeactivateSKU instead") - use `deactivate-sku` instead. (An already-inactive SKU accepts `false` and simply stays inactive.) Reactivating an inactive SKU (`active=true`) additionally requires the provider to be active.
 
 ### Example: Update Price
 

--- a/x/sku/docs/TROUBLESHOOTING.md
+++ b/x/sku/docs/TROUBLESHOOTING.md
@@ -62,7 +62,9 @@ This guide covers common errors and issues users may encounter when using the SK
    ```
 3. Use a valid SKU UUID.
 
-### "invalid sku" (when used in billing)
+### "sku not active" (when used in billing)
+
+**Error**: `sku not active: sku_uuid {uuid} is not active` (codespace `billing`, code 11)
 
 **Cause**: The SKU exists but is not active. Inactive SKUs cannot be used for new leases.
 
@@ -96,6 +98,21 @@ manifestd tx sku create-sku [provider-uuid] "Compute Medium" 1 7200upwr --from a
 # This will fail with "invalid sku" error
 manifestd tx sku create-sku [provider-uuid] "Bad SKU" 1 3601upwr --from authority
 ```
+
+**Second failure mode (price too small)**: If the base price is smaller than the
+unit's divisor (< 3600 for UNIT_PER_HOUR, < 86400 for UNIT_PER_DAY), the
+per-second rate truncates to zero and the transaction fails with a different
+message: `base price {price} with unit {unit} results in zero per-second rate; increase price or change unit`.
+This is checked *before* the divisibility check.
+
+```bash
+# Invalid: 1000 / 3600 truncates to 0 per second
+# This will fail with the "zero per-second rate" message
+manifestd tx sku create-sku [provider-uuid] "Too Cheap" 1 1000upwr --from authority
+```
+
+**Solution**: Raise the price to at least the divisor, or switch to
+`UNIT_PER_DAY` so the smaller divisor keeps the per-second rate non-zero.
 
 ---
 
@@ -152,7 +169,9 @@ manifestd tx sku create-provider manifest1... manifest1... --api-url https://api
 
 ## Parameter Issues
 
-### "invalid params" (duplicate addresses)
+### "invalid module configuration" (duplicate addresses)
+
+**Error**: `invalid module configuration: invalid params: invalid module configuration: duplicate address in allowed list: {addr}`
 
 **Cause**: The `allowed_list` contains duplicate addresses.
 
@@ -180,11 +199,15 @@ manifestd tx sku update-params --allowed-list "manifest1abc..." --from authority
 
 ### Deactivating an already inactive provider/SKU
 
-**Behavior**: Attempting to deactivate an already inactive provider or SKU returns an error.
+**Behavior**: The two cases differ:
+- **SKU**: Deactivating an already inactive SKU always returns an error.
+- **Provider**: Deactivating an already inactive provider returns an error **only if all of its SKUs are also inactive**. If the provider still has active SKUs, the call is treated as a continuation of the paginated SKU cascade and succeeds (see note below).
 
 **Error Messages:**
-- Provider: `invalid provider: provider {uuid} is already inactive`
+- Provider (only when all SKUs are already inactive): `invalid provider: provider {uuid} and all its SKUs are already inactive`
 - SKU: `invalid sku: sku {uuid} is already inactive`
+
+**Note**: `DeactivateProvider` deactivates a provider's SKUs in pages (`DefaultDeactivateSKULimit` = 50, `MaxDeactivateSKULimit` = 100). When the response reports `has_more` = true, the provider is already inactive but SKUs remain; you must **re-invoke** `DeactivateProvider` while `has_more` is true. Re-invocation on an already-inactive provider is the normal, expected flow and is **not** an error condition.
 
 **Solution**: Check the provider/SKU status before deactivation:
 ```bash
@@ -213,15 +236,19 @@ manifestd query sku sku [sku-uuid]
 
 ---
 
-## Query Issues
+## UUID Format Issues
 
-### "invalid uuid format"
+### "invalid UUIDv7 format"
 
-**Cause**: The UUID is not in valid UUIDv7 format.
+**Error**: `invalid UUIDv7 format: {uuid}` (typically surfaced wrapped, e.g. `invalid provider: invalid uuid: invalid UUIDv7 format: ...`)
 
-**Solution**: Ensure you're using a valid UUID (format: `xxxxxxxx-xxxx-7xxx-xxxx-xxxxxxxxxxxx`):
+**Cause**: The UUID is not in valid UUIDv7 format. This error is raised only by **transactions** (update/deactivate provider or SKU, and create-sku's `provider_uuid`) during message validation — **not** by queries. Queries do not validate UUID format: a malformed UUID passed to `query sku provider` / `query sku sku` is looked up as-is and returns `provider not found` / `sku not found` instead.
+
+**Format constraints** (see the UUIDv7 regex): lowercase hex digits only, the version nibble must be `7`, and the variant nibble must be one of `8`, `9`, `a`, or `b`. Uppercase UUIDs are rejected.
+
+**Solution**: Ensure you're using a valid UUID (format: `xxxxxxxx-xxxx-7xxx-yxxx-xxxxxxxxxxxx`, where `y` is `8`/`9`/`a`/`b`):
 ```bash
-manifestd query sku provider 01912345-6789-7abc-8def-0123456789ab
+manifestd tx sku deactivate-provider 01912345-6789-7abc-8def-0123456789ab --from authority
 ```
 
 ---

--- a/x/sku/docs/TROUBLESHOOTING.md
+++ b/x/sku/docs/TROUBLESHOOTING.md
@@ -111,8 +111,11 @@ This is checked *before* the divisibility check.
 manifestd tx sku create-sku [provider-uuid] "Too Cheap" 1 1000upwr --from authority
 ```
 
-**Solution**: Raise the price to at least the divisor, or switch to
-`UNIT_PER_DAY` so the smaller divisor keeps the per-second rate non-zero.
+**Solution**: Raise the base price to at least the unit's divisor (≥ 3600 for
+`UNIT_PER_HOUR`, ≥ 86400 for `UNIT_PER_DAY`) and keep it evenly divisible. A
+coarser unit has a *larger* divisor, so `UNIT_PER_DAY` (86400) makes the
+zero-rate failure **more** likely, not less — prefer the finer `UNIT_PER_HOUR`
+or simply raise the price.
 
 ---
 


### PR DESCRIPTION
## Summary

Audit and re-sync of all SKU and billing documentation against the code at v2.3.1. The last doc refresh targeted v2.1.0; four feature releases landed after it (ENG-475 provider-withdraw cursor pagination, lease-item `custom_domain`/`service_name`, the `provider_uuid` custom-domain event attribute, and ENG-527 credit-estimate caps), leaving the docs materially stale. This PR reconciles **114 findings** across 17 files, split into three commits by area.

Every fix was verified against the cited source before editing, re-checked by a second pass, and spot-checked for exact error strings, event names, and constants.

## Highlights

**Fund-safety correction (billing):** the overflow-settlement docs described the *inverse* of the code. On accrual overflow the silent settlement path sweeps the tenant's entire remaining credit to the provider and force-closes the lease (`settlement.go`); the docs claimed the lease is "silently skipped" with "funds preserved." The behavior is intentional and effectively unreachable in normal operation (it requires a settlement duration beyond `MaxDurationSeconds` ≈ 100 years), but the docs now match the code.

**Event contract (billing):** credit-exhaustion auto-close emits three different events depending on the trigger path — `lease_closed` (`closed_by=credit_exhaustion`) from `MsgCloseLease`, `provider_withdraw` (`auto_closed=true`) from specific-lease `MsgWithdraw`, and `lease_auto_closed` (`reason=credit_exhausted`) only from provider-wide `MsgWithdraw`. Docs and the frontend guide previously told integrators to watch only `lease_auto_closed`.

**ENG-475 pagination (billing + frontend):** removed `limit`/`has_more`, added the opaque `key`/`next_key` cursor, ACTIVE-only per-page `ProviderWithdrawable`. The `docs/FRONTEND.md` `withdrawAll` sample never echoed the cursor and looped forever — now fixed.

**Deactivation cascade (sku):** provider deactivation is paginated (`limit` default 50, max 100, `has_more`), not an automatic all-at-once cascade, across the README and both task guides.

**Won't-start genesis + fabricated API (sku):** the README genesis example omitted `provider_sequence`/`sku_sequence` (validation rejects sequence < entity count, so the chain won't start); `ARCHITECTURE.md` documented a `ValidatePriceDivisibility` function that does not exist — replaced with the real `ValidatePriceAndUnit`.

Plus a long tail of exact error-string, event-attribute, param-bound, base64 `meta_hash`, authorization-scope, and drifted-diagram/snippet corrections.

## Commits
- `docs(billing): sync module docs with code through v2.3.1`
- `docs(sku): sync module docs with code`
- `docs(frontend): fix broken withdraw pagination and auth samples`

## Verification
Docs-only change; no code touched. Verified by re-reading each edited file against the cited implementation, checking code-fence balance, and confirming no non-doc files were modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)