### PR TITLE
fix(sku): bound MetaHash length in genesis Validate() (ENG-541)

### DIFF
--- a/x/sku/types/genesis.go
+++ b/x/sku/types/genesis.go
@@ -66,6 +66,10 @@ func (gs *GenesisState) Validate() error {
 				return ErrInvalidProvider.Wrapf("provider %s has invalid api_url: %s", provider.Uuid, err)
 			}
 		}
+
+		if len(provider.MetaHash) > MaxMetaHashLength {
+			return ErrInvalidProvider.Wrapf("provider %s meta_hash exceeds maximum length of %d bytes", provider.Uuid, MaxMetaHashLength)
+		}
 	}
 
 	// Validate SKUs
@@ -108,6 +112,10 @@ func (gs *GenesisState) Validate() error {
 		// Validate that price and unit combination produces a valid per-second rate
 		if err := ValidatePriceAndUnit(sku.BasePrice, sku.Unit); err != nil {
 			return ErrInvalidSKU.Wrapf("sku %s has invalid price/unit combination: %s", sku.Uuid, err)
+		}
+
+		if len(sku.MetaHash) > MaxMetaHashLength {
+			return ErrInvalidSKU.Wrapf("sku %s meta_hash exceeds maximum length of %d bytes", sku.Uuid, MaxMetaHashLength)
 		}
 	}
 

--- a/x/sku/types/genesis_test.go
+++ b/x/sku/types/genesis_test.go
@@ -206,6 +206,109 @@ func TestGenesisState_Validate(t *testing.T) {
 			},
 			expectErr: false,
 		},
+		{
+			name: "invalid: provider meta_hash exceeds max length",
+			genesis: &GenesisState{
+				Params: DefaultParams(),
+				Providers: []Provider{
+					{
+						Uuid:          "01912345-6789-7abc-8def-0123456789ab",
+						Address:       providerAddr,
+						PayoutAddress: payoutAddr,
+						MetaHash:      make([]byte, MaxMetaHashLength+1),
+						Active:        true,
+					},
+				},
+				Skus:             []SKU{},
+				ProviderSequence: 1,
+			},
+			expectErr: true,
+			errMsg:    "meta_hash exceeds maximum length",
+		},
+		{
+			name: "valid: provider meta_hash at max length",
+			genesis: &GenesisState{
+				Params: DefaultParams(),
+				Providers: []Provider{
+					{
+						Uuid:          "01912345-6789-7abc-8def-0123456789ab",
+						Address:       providerAddr,
+						PayoutAddress: payoutAddr,
+						MetaHash:      make([]byte, MaxMetaHashLength),
+						Active:        true,
+					},
+				},
+				Skus:             []SKU{},
+				ProviderSequence: 1,
+			},
+			expectErr: false,
+		},
+		{
+			name: "invalid: SKU meta_hash exceeds max length",
+			genesis: &GenesisState{
+				Params:    DefaultParams(),
+				Providers: []Provider{validProvider},
+				Skus: []SKU{
+					{
+						Uuid:         "01912345-6789-7abc-8def-0123456789ac",
+						ProviderUuid: validProvider.Uuid,
+						Name:         "Test SKU",
+						Unit:         Unit_UNIT_PER_HOUR,
+						BasePrice:    sdk.NewCoin("umfx", math.NewInt(3600)),
+						MetaHash:     make([]byte, MaxMetaHashLength+1),
+						Active:       true,
+					},
+				},
+				ProviderSequence: 1,
+				SkuSequence:      1,
+			},
+			expectErr: true,
+			errMsg:    "meta_hash exceeds maximum length",
+		},
+		{
+			name: "valid: SKU meta_hash at max length",
+			genesis: &GenesisState{
+				Params:    DefaultParams(),
+				Providers: []Provider{validProvider},
+				Skus: []SKU{
+					{
+						Uuid:         "01912345-6789-7abc-8def-0123456789ac",
+						ProviderUuid: validProvider.Uuid,
+						Name:         "Test SKU",
+						Unit:         Unit_UNIT_PER_HOUR,
+						BasePrice:    sdk.NewCoin("umfx", math.NewInt(3600)),
+						MetaHash:     make([]byte, MaxMetaHashLength),
+						Active:       true,
+					},
+				},
+				ProviderSequence: 1,
+				SkuSequence:      1,
+			},
+			expectErr: false,
+		},
+		{
+			name: "invalid: second SKU meta_hash exceeds max length",
+			genesis: &GenesisState{
+				Params:    DefaultParams(),
+				Providers: []Provider{validProvider},
+				Skus: []SKU{
+					validSKU,
+					{
+						Uuid:         "01912345-6789-7abc-8def-0123456789ad",
+						ProviderUuid: validProvider.Uuid,
+						Name:         "Second SKU",
+						Unit:         Unit_UNIT_PER_HOUR,
+						BasePrice:    sdk.NewCoin("umfx", math.NewInt(3600)),
+						MetaHash:     make([]byte, MaxMetaHashLength+1),
+						Active:       true,
+					},
+				},
+				ProviderSequence: 1,
+				SkuSequence:      2,
+			},
+			expectErr: true,
+			errMsg:    "meta_hash exceeds maximum length",
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

Adds the `MetaHash` length bound to sku `GenesisState.Validate()` for both `Provider` and `SKU` (ENG-541, item 1). The message path already bounds `MetaHash` to `MaxMetaHashLength` on all four provider/SKU create/update handlers, and billing genesis enforces its equivalent — sku genesis was the one gap. An oversized `meta_hash` in a hand-edited or hard-forked genesis is now rejected by `validate-genesis`, matching the message path and billing for symmetry.

- Provider loop and SKU loop each gain `len(MetaHash) > MaxMetaHashLength` → `ErrInvalidProvider` / `ErrInvalidSKU`.
- No tx-path behavior change; genesis-only hardening. Security severity NONE/LOW (genesis is operator/governance-controlled, not attacker-reachable).

## Tests

Table-driven cases in `x/sku/types/genesis_test.go` (written test-first):
- invalid + at-max boundary for Provider `meta_hash`
- invalid + at-max boundary for SKU `meta_hash`
- non-first-entity case (second SKU carries the oversized hash) to guard the range loop

`go build ./...`, `go vet ./x/sku/...`, `gofmt`, and `go test ./x/sku/...` all pass.

## Scope note — item 2

ENG-541 item 2 (whether `InitGenesis` should call `gs.Validate()`) is intentionally **not** in this PR. Per the standard Cosmos SDK pattern — `Manager.InitGenesis` does not auto-validate, and x/bank, x/staking, x/gov do not re-run `Validate()` in `InitGenesis` — full structural validation belongs in `AppModuleBasic.ValidateGenesis` / the offline `validate-genesis` command, which both modules already wire up. Recommended resolution for item 2: **no code change** (current design is idiomatic).

Provenance: 2026-07-16 automated multi-agent security audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
