### PR TITLE
fix(billing): only mark CloseLease credit_exhausted on a genuine shortfall (ENG-577)

### DIFF
--- a/x/billing/README.md
+++ b/x/billing/README.md
@@ -173,7 +173,7 @@ If a tenant's credit balance is insufficient to cover accrued charges, the billi
 
 | Trigger | Event | Distinguishing attribute |
 |---|---|---|
-| `MsgCloseLease` | `lease_closed` | `closed_by = credit_exhaustion` — only when the settlement genuinely falls short; a fully-paid close keeps the caller's `reason`/role |
+| `MsgCloseLease` | `lease_closed` | `closed_by = credit_exhaustion` on a genuine exhaustion (shortfall, accrual overflow, or a zero-balance close); a fully-paid close keeps the caller's `reason`/role |
 | `MsgWithdraw` (specific lease UUIDs) | `provider_withdraw` | `auto_closed = true` (with `amount = 0`) |
 | `MsgWithdraw` (provider-wide) | `lease_auto_closed` | `reason = credit_exhausted` |
 

--- a/x/billing/README.md
+++ b/x/billing/README.md
@@ -173,7 +173,7 @@ If a tenant's credit balance is insufficient to cover accrued charges, the billi
 
 | Trigger | Event | Distinguishing attribute |
 |---|---|---|
-| `MsgCloseLease` | `lease_closed` | `closed_by = credit_exhaustion` |
+| `MsgCloseLease` | `lease_closed` | `closed_by = credit_exhaustion` — only when the settlement genuinely falls short; a fully-paid close keeps the caller's `reason`/role |
 | `MsgWithdraw` (specific lease UUIDs) | `provider_withdraw` | `auto_closed = true` (with `amount = 0`) |
 | `MsgWithdraw` (provider-wide) | `lease_auto_closed` | `reason = credit_exhausted` |
 

--- a/x/billing/docs/ARCHITECTURE.md
+++ b/x/billing/docs/ARCHITECTURE.md
@@ -470,7 +470,7 @@ sequenceDiagram
             else Authorized
                 alt ShouldAutoCloseLease (credit exhausted)
                     Keeper->>Keeper: PerformSettlementSilent()
-                    Note over Keeper: closure_reason = "credit exhausted"<br/>closed_by = "credit_exhaustion" (msg.Reason ignored)
+                    Note over Keeper: closure_reason = "credit exhausted", closed_by = "credit_exhaustion"<br/>only on a genuine shortfall (overflow, partial settlement, or zero balance);<br/>a full payment preserves msg.Reason and the caller role
                 else Normal close
                     Keeper->>Keeper: settleLease()
                     Note over Keeper: closure_reason = msg.Reason

--- a/x/billing/docs/CAPABILITIES.md
+++ b/x/billing/docs/CAPABILITIES.md
@@ -87,7 +87,7 @@ This design enables:
 When credit is exhausted:
 1. Transfer available balance to provider (partial payment)
 2. Auto-close the lease
-3. Emit an auto-close event whose type depends on the path: `lease_auto_closed` (reason=`credit_exhausted`) from provider-wide withdraw; `lease_closed` with `closed_by=credit_exhaustion` from CloseLease (only when the close settles short of accrued charges — a fully-paid CloseLease keeps the caller's reason/role); `provider_withdraw` with `auto_closed=true` from specific-lease withdraw
+3. Emit an auto-close event whose type depends on the path: `lease_auto_closed` (reason=`credit_exhausted`) from provider-wide withdraw; `lease_closed` with `closed_by=credit_exhaustion` from CloseLease on a genuine exhaustion (shortfall, accrual overflow, or a zero-balance close) — a fully-paid CloseLease keeps the caller's reason/role; `provider_withdraw` with `auto_closed=true` from specific-lease withdraw
 
 ### Overflow Protection
 

--- a/x/billing/docs/CAPABILITIES.md
+++ b/x/billing/docs/CAPABILITIES.md
@@ -87,7 +87,7 @@ This design enables:
 When credit is exhausted:
 1. Transfer available balance to provider (partial payment)
 2. Auto-close the lease
-3. Emit an auto-close event whose type depends on the path: `lease_auto_closed` (reason=`credit_exhausted`) from provider-wide withdraw; `lease_closed` with `closed_by=credit_exhaustion` from CloseLease; `provider_withdraw` with `auto_closed=true` from specific-lease withdraw
+3. Emit an auto-close event whose type depends on the path: `lease_auto_closed` (reason=`credit_exhausted`) from provider-wide withdraw; `lease_closed` with `closed_by=credit_exhaustion` from CloseLease (only when the close settles short of accrued charges — a fully-paid CloseLease keeps the caller's reason/role); `provider_withdraw` with `auto_closed=true` from specific-lease withdraw
 
 ### Overflow Protection
 

--- a/x/billing/docs/TROUBLESHOOTING.md
+++ b/x/billing/docs/TROUBLESHOOTING.md
@@ -498,7 +498,7 @@ manifestd query tx [txhash] --output json | jq '.events'
 ```
 
 Events to look for (the event depends on which write path triggered the auto-close):
-- `lease_closed` with `closed_by="credit_exhaustion"` (auto-close via `CloseLease`)
+- `lease_closed` with `closed_by="credit_exhaustion"` (auto-close via `CloseLease`; a fully-paid `CloseLease` instead keeps the caller-supplied `closure_reason`/role)
 - `provider_withdraw` with `auto_closed="true"` (auto-close via specific-lease `Withdraw`)
 - `lease_auto_closed` with `reason="credit_exhausted"` (auto-close via provider-wide `Withdraw`)
 

--- a/x/billing/keeper/msg_server.go
+++ b/x/billing/keeper/msg_server.go
@@ -529,9 +529,18 @@ func (ms msgServer) CloseLease(ctx context.Context, msg *types.MsgCloseLease) (*
 			// shared credit balance so a later, fully-paid lease trips the boundary
 			// with nothing left unpaid. That is a full payment, not credit
 			// exhaustion. Only relabel the close as credit-exhausted when the
-			// settlement genuinely fell short (accrued > transferred); otherwise
-			// honour the caller-supplied reason and role (ENG-577).
-			if unpaid := result.AccruedAmounts.Sub(result.TransferAmounts...); !unpaid.IsZero() {
+			// settlement genuinely fell short; otherwise honour the caller-supplied
+			// reason and role (ENG-577).
+			//
+			// Two distinct shortfalls count as exhaustion: (1) accrual overflow,
+			// where PerformSettlementSilent clamps AccruedAmounts to the remaining
+			// balance and transfers it all — so `unpaid` reads zero and must be
+			// detected via the same duration threshold the accrual layer uses; and
+			// (2) an ordinary partial settlement where the transfer fell short of
+			// the accrued amount.
+			overflowed := int64(duration/time.Second) > MaxDurationSeconds
+			unpaid := result.AccruedAmounts.Sub(result.TransferAmounts...)
+			if overflowed || !unpaid.IsZero() {
 				leases[i].ClosureReason = types.ClosureReasonCreditExhausted
 				leaseClosedBy = "credit_exhaustion"
 			} else {

--- a/x/billing/keeper/msg_server.go
+++ b/x/billing/keeper/msg_server.go
@@ -522,9 +522,21 @@ func (ms msgServer) CloseLease(ctx context.Context, msg *types.MsgCloseLease) (*
 			leases[i].State = types.LEASE_STATE_CLOSED
 			leases[i].ClosedAt = &closeTime
 			leases[i].LastSettledAt = closeTime
-			leases[i].ClosureReason = types.ClosureReasonCreditExhausted
 
-			leaseClosedBy = "credit_exhaustion"
+			// ShouldAutoCloseLease uses a GTE boundary (accrued >= balance), so it
+			// also fires when the tenant's credit EXACTLY covers the accrued
+			// charges — and in a batch an earlier lease's settlement can drain the
+			// shared credit balance so a later, fully-paid lease trips the boundary
+			// with nothing left unpaid. That is a full payment, not credit
+			// exhaustion. Only relabel the close as credit-exhausted when the
+			// settlement genuinely fell short (accrued > transferred); otherwise
+			// honour the caller-supplied reason and role (ENG-577).
+			if unpaid := result.AccruedAmounts.Sub(result.TransferAmounts...); !unpaid.IsZero() {
+				leases[i].ClosureReason = types.ClosureReasonCreditExhausted
+				leaseClosedBy = "credit_exhaustion"
+			} else {
+				leases[i].ClosureReason = msg.Reason
+			}
 		} else {
 			// Normal close - use block time
 			closeTime = blockTime

--- a/x/billing/keeper/msg_server.go
+++ b/x/billing/keeper/msg_server.go
@@ -527,20 +527,23 @@ func (ms msgServer) CloseLease(ctx context.Context, msg *types.MsgCloseLease) (*
 			// also fires when the tenant's credit EXACTLY covers the accrued
 			// charges — and in a batch an earlier lease's settlement can drain the
 			// shared credit balance so a later, fully-paid lease trips the boundary
-			// with nothing left unpaid. That is a full payment, not credit
-			// exhaustion. Only relabel the close as credit-exhausted when the
-			// settlement genuinely fell short; otherwise honour the caller-supplied
-			// reason and role (ENG-577).
+			// with nothing left unpaid. That is a full payment (the credit did its
+			// job), not exhaustion, so the caller-supplied reason and role are
+			// preserved (ENG-577).
 			//
-			// Two distinct shortfalls count as exhaustion: (1) accrual overflow,
-			// where PerformSettlementSilent clamps AccruedAmounts to the remaining
-			// balance and transfers it all — so `unpaid` reads zero and must be
-			// detected via the same duration threshold the accrual layer uses; and
-			// (2) an ordinary partial settlement where the transfer fell short of
-			// the accrued amount.
+			// Keep the caller's reason ONLY when a positive accrued charge was
+			// settled in full. Everything else ShouldAutoCloseLease flags is genuine
+			// exhaustion and keeps the credit_exhausted label:
+			//   - overflow: PerformSettlementSilent clamps AccruedAmounts to the
+			//     remaining balance and transfers it all, so `unpaid` reads zero;
+			//     detect it via the same duration threshold the accrual layer uses.
+			//   - partial settlement: the transfer fell short of the accrued amount.
+			//   - zero-balance / zero-duration: a required denom balance is already
+			//     zero with nothing accrued this instant (AccruedAmounts empty) — the
+			//     credit is exhausted even though there is no unpaid remainder.
 			overflowed := int64(duration/time.Second) > MaxDurationSeconds
 			unpaid := result.AccruedAmounts.Sub(result.TransferAmounts...)
-			if overflowed || !unpaid.IsZero() {
+			if overflowed || !unpaid.IsZero() || result.AccruedAmounts.IsZero() {
 				leases[i].ClosureReason = types.ClosureReasonCreditExhausted
 				leaseClosedBy = "credit_exhaustion"
 			} else {

--- a/x/billing/keeper/msg_server_test.go
+++ b/x/billing/keeper/msg_server_test.go
@@ -1694,6 +1694,39 @@ func TestMsgCloseLease_CreditExhaustionLabelling(t *testing.T) {
 		require.Equal(t, types.ClosureReasonCreditExhausted, closed.ClosureReason,
 			"an overflow-driven close (accrued beyond representable range) is genuine exhaustion")
 	})
+
+	t.Run("zero balance with zero elapsed time is still credit_exhausted", func(t *testing.T) {
+		// tenant3's earlier lease is already closed; reuse and re-fund it.
+		tenant := f.TestAccs[3]
+		fundTenant(t, tenant, 100)
+		creditAddr, err := types.DeriveCreditAddressFromBech32(tenant.String())
+		require.NoError(t, err)
+
+		leaseID := f.createAndAcknowledgeLease(t, msgServer, tenant, providerAddr, []types.LeaseItemInput{
+			{SkuUuid: sku.Uuid, Quantity: 1},
+		})
+
+		// Drain the credit balance to zero WITHOUT advancing block time, so the
+		// close sees duration == 0 and a zero balance. ShouldAutoCloseLease flags
+		// this via its zero-balance branch, but PerformSettlementSilent accrues and
+		// transfers nothing (duration == 0), so there is no unpaid remainder — the
+		// close must still be recorded as genuine credit exhaustion, not the reason.
+		bal := f.App.BankKeeper.GetBalance(f.Ctx, creditAddr, denom)
+		require.NoError(t, f.App.BankKeeper.SendCoins(f.Ctx, creditAddr, payoutAddr, sdk.NewCoins(bal)))
+
+		_, err = msgServer.CloseLease(f.Ctx, &types.MsgCloseLease{
+			Sender:     tenant.String(),
+			LeaseUuids: []string{leaseID},
+			Reason:     "should-be-credit-exhausted",
+		})
+		require.NoError(t, err)
+
+		lease, err := f.App.BillingKeeper.GetLease(f.Ctx, leaseID)
+		require.NoError(t, err)
+		require.Equal(t, types.LEASE_STATE_CLOSED, lease.State)
+		require.Equal(t, types.ClosureReasonCreditExhausted, lease.ClosureReason,
+			"a zero-balance lease closed with no time elapsed is genuine exhaustion")
+	})
 }
 
 // TestMsgCloseLease_ProviderClose tests that provider can close a lease.

--- a/x/billing/keeper/msg_server_test.go
+++ b/x/billing/keeper/msg_server_test.go
@@ -1520,10 +1520,10 @@ func TestMsgCloseLease_PartialSettlement(t *testing.T) {
 }
 
 // TestMsgCloseLease_CreditExhaustionLabelling verifies that a voluntary close is
-// only recorded as credit_exhausted on a genuine shortfall (accrued > balance).
-// When the tenant's credit exactly covers the accrued charges (accrued == balance,
-// the ShouldAutoCloseLease GTE boundary) the caller's reason and role must be
-// preserved. Regression for ENG-577.
+// only recorded as credit_exhausted on a genuine shortfall. When the tenant's
+// credit exactly covers the accrued charges — the accrued == balance case that
+// ShouldAutoCloseLease's GTE boundary also treats as exhaustion — the caller's
+// reason and role must be preserved. Regression for ENG-577.
 func TestMsgCloseLease_CreditExhaustionLabelling(t *testing.T) {
 	f := initFixture(t)
 	msgServer := keeper.NewMsgServerImpl(f.App.BillingKeeper)
@@ -1661,6 +1661,38 @@ func TestMsgCloseLease_CreditExhaustionLabelling(t *testing.T) {
 			require.Equal(t, reason, lease.ClosureReason,
 				"lease %s: batch drawdown must not relabel a fully-paid close", id)
 		}
+	})
+
+	t.Run("overflow: an unsettled-for-a-century lease is still credit_exhausted", func(t *testing.T) {
+		// tenant0's earlier lease is already closed; reuse and re-fund it.
+		tenant := f.TestAccs[0]
+		fundTenant(t, tenant, 5000)
+
+		leaseID := f.createAndAcknowledgeLease(t, msgServer, tenant, providerAddr, []types.LeaseItemInput{
+			{SkuUuid: sku.Uuid, Quantity: 1},
+		})
+
+		// Force the lease to look >100 years unsettled so accrual overflows.
+		// PerformSettlementSilent then clamps the accrued amount to the remaining
+		// balance and transfers it all (so the unpaid remainder reads zero) — the
+		// close must still be recorded as credit exhaustion, not the caller reason.
+		lease, err := f.App.BillingKeeper.GetLease(f.Ctx, leaseID)
+		require.NoError(t, err)
+		lease.LastSettledAt = f.Ctx.BlockTime().Add(-time.Duration(keeper.MaxDurationSeconds+10) * time.Second)
+		require.NoError(t, f.App.BillingKeeper.SetLease(f.Ctx, lease))
+
+		_, err = msgServer.CloseLease(f.Ctx, &types.MsgCloseLease{
+			Sender:     tenant.String(),
+			LeaseUuids: []string{leaseID},
+			Reason:     "should-be-credit-exhausted",
+		})
+		require.NoError(t, err)
+
+		closed, err := f.App.BillingKeeper.GetLease(f.Ctx, leaseID)
+		require.NoError(t, err)
+		require.Equal(t, types.LEASE_STATE_CLOSED, closed.State)
+		require.Equal(t, types.ClosureReasonCreditExhausted, closed.ClosureReason,
+			"an overflow-driven close (accrued beyond representable range) is genuine exhaustion")
 	})
 }
 

--- a/x/billing/keeper/msg_server_test.go
+++ b/x/billing/keeper/msg_server_test.go
@@ -1519,6 +1519,151 @@ func TestMsgCloseLease_PartialSettlement(t *testing.T) {
 	require.True(t, creditBalance.Amount.IsZero())
 }
 
+// TestMsgCloseLease_CreditExhaustionLabelling verifies that a voluntary close is
+// only recorded as credit_exhausted on a genuine shortfall (accrued > balance).
+// When the tenant's credit exactly covers the accrued charges (accrued == balance,
+// the ShouldAutoCloseLease GTE boundary) the caller's reason and role must be
+// preserved. Regression for ENG-577.
+func TestMsgCloseLease_CreditExhaustionLabelling(t *testing.T) {
+	f := initFixture(t)
+	msgServer := keeper.NewMsgServerImpl(f.App.BillingKeeper)
+
+	providerAddr := f.TestAccs[1]
+	payoutAddr := f.TestAccs[2]
+	denom := testDenom
+
+	// Short min duration so a small credit balance can back a lease.
+	params := types.DefaultParams()
+	params.MinLeaseDuration = 10
+	require.NoError(t, f.App.BillingKeeper.SetParams(f.Ctx, params))
+
+	provider := f.createTestProvider(t, providerAddr.String(), payoutAddr.String())
+	sku := f.createTestSKU(t, provider.Uuid, 3600) // 3600/hour = 1 umfx/second
+
+	// fundTenant funds a tenant's credit account with exactly `amount` units.
+	fundTenant := func(t *testing.T, tenant sdk.AccAddress, amount int64) {
+		t.Helper()
+		creditAddr, err := types.DeriveCreditAddressFromBech32(tenant.String())
+		require.NoError(t, err)
+		f.fundAccount(t, creditAddr, sdk.NewCoins(sdk.NewCoin(denom, sdkmath.NewInt(amount))))
+		require.NoError(t, f.App.BillingKeeper.SetCreditAccount(f.Ctx, types.CreditAccount{
+			Tenant:        tenant.String(),
+			CreditAddress: creditAddr.String(),
+		}))
+	}
+
+	// closedEventBy returns the closed_by attribute of the lease_closed event for leaseID.
+	closedEventBy := func(leaseID string) string {
+		for _, ev := range f.Ctx.EventManager().Events() {
+			if ev.Type != types.EventTypeLeaseClosed {
+				continue
+			}
+			var uuid, by string
+			for _, a := range ev.Attributes {
+				switch a.Key {
+				case types.AttributeKeyLeaseUUID:
+					uuid = a.Value
+				case types.AttributeKeyClosedBy:
+					by = a.Value
+				}
+			}
+			if uuid == leaseID {
+				return by
+			}
+		}
+		return ""
+	}
+
+	t.Run("exact balance keeps caller reason (accrued == balance)", func(t *testing.T) {
+		tenant := f.TestAccs[0]
+		fundTenant(t, tenant, 100) // rate 1/s -> exactly 100s of runway
+
+		leaseID := f.createAndAcknowledgeLease(t, msgServer, tenant, providerAddr, []types.LeaseItemInput{
+			{SkuUuid: sku.Uuid, Quantity: 1},
+		})
+
+		// Advance exactly 100s: accrued (100) == balance (100).
+		f.Ctx = f.Ctx.WithBlockTime(f.Ctx.BlockTime().Add(100 * time.Second))
+
+		const reason = "migrating-to-new-provider"
+		_, err := msgServer.CloseLease(f.Ctx, &types.MsgCloseLease{
+			Sender:     tenant.String(),
+			LeaseUuids: []string{leaseID},
+			Reason:     reason,
+		})
+		require.NoError(t, err)
+
+		lease, err := f.App.BillingKeeper.GetLease(f.Ctx, leaseID)
+		require.NoError(t, err)
+		require.Equal(t, types.LEASE_STATE_CLOSED, lease.State)
+		require.Equal(t, reason, lease.ClosureReason,
+			"a fully-paid voluntary close must keep the caller's reason, not credit_exhausted")
+		require.Equal(t, types.AttributeValueRoleTenant, closedEventBy(leaseID),
+			"closed_by must be the caller role, not credit_exhaustion")
+
+		// Full payment: provider received all 100 units.
+		require.Equal(t, sdkmath.NewInt(100), f.App.BankKeeper.GetBalance(f.Ctx, payoutAddr, denom).Amount)
+	})
+
+	t.Run("genuine shortfall is recorded as credit_exhausted (accrued > balance)", func(t *testing.T) {
+		tenant := f.TestAccs[3]
+		fundTenant(t, tenant, 30) // only 30 units of runway
+
+		leaseID := f.createAndAcknowledgeLease(t, msgServer, tenant, providerAddr, []types.LeaseItemInput{
+			{SkuUuid: sku.Uuid, Quantity: 1},
+		})
+
+		// Advance 100s: accrued (100) > balance (30) -> genuine exhaustion.
+		f.Ctx = f.Ctx.WithBlockTime(f.Ctx.BlockTime().Add(100 * time.Second))
+
+		_, err := msgServer.CloseLease(f.Ctx, &types.MsgCloseLease{
+			Sender:     tenant.String(),
+			LeaseUuids: []string{leaseID},
+			Reason:     "should-be-overridden",
+		})
+		require.NoError(t, err)
+
+		lease, err := f.App.BillingKeeper.GetLease(f.Ctx, leaseID)
+		require.NoError(t, err)
+		require.Equal(t, types.LEASE_STATE_CLOSED, lease.State)
+		require.Equal(t, types.ClosureReasonCreditExhausted, lease.ClosureReason,
+			"an under-funded close is a genuine credit exhaustion")
+	})
+
+	t.Run("batch: earlier lease drawdown does not mislabel a fully-paid later lease", func(t *testing.T) {
+		tenant := f.TestAccs[4]
+		fundTenant(t, tenant, 200) // exactly enough for two 1/s leases over 100s
+
+		leaseA := f.createAndAcknowledgeLease(t, msgServer, tenant, providerAddr, []types.LeaseItemInput{
+			{SkuUuid: sku.Uuid, Quantity: 1},
+		})
+		leaseB := f.createAndAcknowledgeLease(t, msgServer, tenant, providerAddr, []types.LeaseItemInput{
+			{SkuUuid: sku.Uuid, Quantity: 1},
+		})
+
+		f.Ctx = f.Ctx.WithBlockTime(f.Ctx.BlockTime().Add(100 * time.Second))
+
+		const reason = "planned-teardown"
+		_, err := msgServer.CloseLease(f.Ctx, &types.MsgCloseLease{
+			Sender:     tenant.String(),
+			LeaseUuids: []string{leaseA, leaseB},
+			Reason:     reason,
+		})
+		require.NoError(t, err)
+
+		// Both leases are fully paid (200 credit == 200 accrued total). Closing A
+		// first drains the shared balance so B settles at exactly zero remaining,
+		// which must NOT be relabelled as credit exhaustion.
+		for _, id := range []string{leaseA, leaseB} {
+			lease, err := f.App.BillingKeeper.GetLease(f.Ctx, id)
+			require.NoError(t, err)
+			require.Equal(t, types.LEASE_STATE_CLOSED, lease.State)
+			require.Equal(t, reason, lease.ClosureReason,
+				"lease %s: batch drawdown must not relabel a fully-paid close", id)
+		}
+	})
+}
+
 // TestMsgCloseLease_ProviderClose tests that provider can close a lease.
 func TestMsgCloseLease_ProviderClose(t *testing.T) {
 	f := initFixture(t)


### PR DESCRIPTION
## Summary

Fixes [ENG-577](https://linear.app/liftedinit/issue/ENG-577). Surfaced by the 2026-07-17 multi-agent audit of `x/sku` + `x/billing`. **Severity LOW** (audit/event accuracy — funds are always conserved).

`CloseLease` runs `ShouldAutoCloseLease` for every lease before honouring the requested close. That check uses a `>=` boundary (`accrued >= balance`, `keeper.go:1027`), so it also fires when the tenant's credit **exactly** covers the accrued charges. In that case the close was routed through the auto-close branch, which overwrote the caller's `Reason` with `credit exhausted` and set `closed_by = credit_exhaustion` — even though the tenant paid in full and explicitly asked to close with their own reason.

**Batch amplification:** `ShouldAutoCloseLease` reads the running cache-context balance, so an earlier lease's settlement drains the shared credit balance, tripping the boundary for a later, fully-paid lease.

## Fix

Only relabel a close as credit-exhausted when the settlement genuinely fell short (`accrued > transferred`); otherwise preserve the caller-supplied reason and role. `ShouldAutoCloseLease` is retained, so its future-`LastSettledAt` guard and overflow → silent-settlement handling are unchanged — only the label decision moved to the post-settlement result.

```go
if unpaid := result.AccruedAmounts.Sub(result.TransferAmounts...); !unpaid.IsZero() {
    leases[i].ClosureReason = types.ClosureReasonCreditExhausted
    leaseClosedBy = "credit_exhaustion"
} else {
    leases[i].ClosureReason = msg.Reason
}
```

## Tests

New `TestMsgCloseLease_CreditExhaustionLabelling`:
- **exact balance** (`accrued == balance`) → keeps caller reason + `closed_by = tenant` *(failed before the fix)*
- **genuine shortfall** (`accrued > balance`) → still `credit_exhausted` *(guards against over-correction)*
- **batch drawdown** → closing A first drains the shared balance so B settles at exactly zero; B must not be relabelled *(failed before the fix)*

Also fills the gap the audit flagged: `TestMsgCloseLease_PartialSettlement` never asserted on the closure reason.

## Verification

- New test green; full `./x/billing/... ./x/sku/...` suites green.
- `gofmt` / `go vet` / `go build` clean; no import changes.

## Note

This changes a stored state field (`ClosureReason`), so it is **consensus-relevant** and should ride the next coordinated upgrade even though there is no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)